### PR TITLE
allow option full path(walker.js)

### DIFF
--- a/lib/walker.js
+++ b/lib/walker.js
@@ -65,7 +65,7 @@ function upon (p, base) {
     p = p.slice(1);
     negate = true;
   }
-  p = path.join(base, p);
+  p = p.startsWith(process.env.HOME) ? p : path.join(base, p);
   if (negate) {
     p = '!' + p;
   }


### PR DESCRIPTION
Just a small change, support to use path.join outside pkg
useful to use exact path in config file