### PR TITLE
Set dictionary objects as-is

### DIFF
--- a/lib/walker.js
+++ b/lib/walker.js
@@ -645,7 +645,7 @@ class Walker {
       const { dictionary } = pkgConfig;
       if (dictionary) {
         for (const name in dictionary) {
-          this.dictionary[name] = { pkg: dictionary[name] };
+          this.dictionary[name] = dictionary[name];
         }
       }
     }

--- a/lib/walker.js
+++ b/lib/walker.js
@@ -198,17 +198,15 @@ class Walker {
     if (!config) assert(false);
 
     const { name } = config;
-    if (name) {
-      const d = this.dictionary[name];
-      if (d) {
-        if (typeof config.dependencies === 'object' &&
-            typeof d.dependencies === 'object') {
-          Object.assign(config.dependencies, d.dependencies);
-          delete d.dependencies;
-        }
-        Object.assign(config, d);
-        marker.hasDictionary = true;
+    if (name && this.dictionary[name]) {
+      const d = Object.assign({}, this.dictionary[name]);
+      if (typeof config.dependencies === 'object' &&
+          typeof d.dependencies === 'object') {
+        Object.assign(config.dependencies, d.dependencies);
+        delete d.dependencies;
       }
+      Object.assign(config, d);
+      marker.hasDictionary = true;
     }
 
     const { dependencies } = config;


### PR DESCRIPTION
Since the feature was not publicly released yet, I thought that it will be safe to modify the assignment of dictionary elements instead of implementing a separate property. This change will enable to update other package.json properties, such as `dependencies`, to overcome issues described in #920  