### PR TITLE
add --always-compile option to compile even public packages

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -16,6 +16,8 @@ export default function help () {
     -d, --debug      show more information during packaging process [off]
     -b, --build      don't download prebuilt base binaries, build them
     --public         speed up and disclose the sources of top-level project
+    --always-compile compile even public packages 
+                     (i.e. packages inside node_modules)
 
   ${chalk.dim('Examples:')}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,7 @@ async function needViaCache (target) {
 export async function exec (argv2) { // eslint-disable-line complexity
   const argv = minimist(argv2, {
     boolean: [ 'b', 'build', 'bytecode', 'd', 'debug',
-      'h', 'help', 'public', 'v', 'version' ],
+      'h', 'help', 'public', 'v', 'version', 'always-compile' ],
     string: [ '_', 'c', 'config', 'o', 'options', 'output',
       'outdir', 'out-dir', 'out-path', 'public-packages',
       't', 'target', 'targets' ],
@@ -406,6 +406,12 @@ export async function exec (argv2) { // eslint-disable-line complexity
     if (params.publicPackages.indexOf('*') !== -1) {
       params.publicPackages = [ '*' ];
     }
+  }
+
+  // always-compile
+  
+  if (argv['always-compile']) {
+    params.alwaysCompile = true;
   }
 
   // records

--- a/lib/walker.js
+++ b/lib/walker.js
@@ -161,6 +161,7 @@ class Walker {
       }
     } else {
       let { files } = config;
+      const { alwaysCompile } = this.params;
 
       if (files) {
         files = expandFiles(files, base);
@@ -170,6 +171,9 @@ class Walker {
             // 1) remove sources of top-level(!) package 'files' i.e. ship as BLOB
             // 2) non-source (non-js) files of top-level package are shipped as CONTENT
             // 3) parsing some js 'files' of non-top-level packages fails, hence all CONTENT
+            // 4) if --always-compile is specified, 'js' files of non-top-level packages will be ship as BLOB
+
+            const alwaysCompileJS = alwaysCompile && isDotJS(file);
             if (marker.toplevel) {
               this.append({
                 file,
@@ -181,7 +185,7 @@ class Walker {
               this.append({
                 file,
                 marker,
-                store: STORE_CONTENT,
+                store: alwaysCompileJS ? STORE_BLOB : STORE_CONTENT,
                 reason: configPath
               });
             }
@@ -550,10 +554,12 @@ class Walker {
 
       if (marker.public ||
           marker.hasDictionary) {
+        const { alwaysCompile } = this.params;
+        const alwaysCompileJS = alwaysCompile && isDotJS(record.file);
         this.append({
           file: record.file,
           marker,
-          store: STORE_CONTENT
+          store: alwaysCompileJS ? STORE_BLOB : STORE_CONTENT
         });
       }
     }


### PR DESCRIPTION
background:
In case of those users who deployed internal npm servers, their core bussiness logic may stay in `node_modules` directory, so they might  want to compile js files in `node_modules` to protect their sources.

and I think this may be a nice feature , so I add an option for cli users .