### PR TITLE
add --no-derivatives

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -6,16 +6,17 @@ export default function help () {
 
   ${chalk.dim('Options:')}
 
-    -h, --help       output usage information
-    -v, --version    output pkg version
-    -t, --targets    comma-separated list of targets (see examples)
-    -c, --config     package.json or any json file with top-level config
-    --options        bake v8 options into executable to run with them on
-    -o, --output     output file name or template for several files
-    --out-path       path to save output one or more executables
-    -d, --debug      show more information during packaging process [off]
-    -b, --build      don't download prebuilt base binaries, build them
-    --public         speed up and disclose the sources of top-level project
+    -h, --help          output usage information
+    -v, --version       output pkg version
+    -t, --targets       comma-separated list of targets (see examples)
+    -c, --config        package.json or any json file with top-level config
+    --options           bake v8 options into executable to run with them on
+    -o, --output        output file name or template for several files
+    --out-path          path to save output one or more executables
+    -d, --debug         show more information during packaging process [off]
+    -b, --build         don't download prebuilt base binaries, build them
+    --public            speed up and disclose the sources of top-level project
+    --no-derivatives    customize the package content by yourself
 
   ${chalk.dim('Examples:')}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,11 +123,11 @@ async function needViaCache (target) {
 export async function exec (argv2) { // eslint-disable-line complexity
   const argv = minimist(argv2, {
     boolean: [ 'b', 'build', 'bytecode', 'd', 'debug',
-      'h', 'help', 'public', 'v', 'version' ],
+      'h', 'help', 'public', 'v', 'version', 'derivatives' ],
     string: [ '_', 'c', 'config', 'o', 'options', 'output',
       'outdir', 'out-dir', 'out-path', 'public-packages',
       't', 'target', 'targets' ],
-    default: { bytecode: true }
+    default: { bytecode: true, derivatives: true }
   });
 
   if (argv.h || argv.help) {
@@ -397,7 +397,9 @@ export async function exec (argv2) { // eslint-disable-line complexity
 
   // public
 
-  const params = {};
+  const params = {
+    derivatives: argv.derivatives
+  };
   if (argv.public) {
     params.publicToplevel = true;
   }

--- a/lib/walker.js
+++ b/lib/walker.js
@@ -499,6 +499,7 @@ class Walker {
   }
 
   async stepDerivatives (record, marker, derivatives) {
+    if (!this.params.derivatives) return;
     for (const derivative of derivatives) {
       if (natives[derivative.alias]) continue;
 


### PR DESCRIPTION
#### background:
I need to extract all the contents of `node_modules`, set the `NODE_PATH` environment variable, and read the external `node_modules` through the dependencies of `node`, so that my binary files will not be large

so I plan to use an option to set whether to complete the packaging based on the `assets` and `script` set in the `pkg config`without automatically looking for dependencies.

such as this issue(#1019)