### PR TITLE
Support newer node versions which changed internalModuleReadJSON

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -1192,9 +1192,7 @@ function payloadFileSync (pointer) {
 
   fs.internalModuleReadFile = fs.internalModuleReadJSON = function (long) {
     // from node comments:
-    // Used to speed up module loading. Returns the contents of the file as
-    // a string or undefined when the file cannot be opened. The speedup
-    // comes from not creating Error objects on failure.
+    // Used to speed up module loading. Returns an array [string, boolean]
 
     var path = revertMakingLong(long);
     var bindingFs = process.binding('fs');
@@ -1210,10 +1208,10 @@ function payloadFileSync (pointer) {
     path = normalizePath(path);
     // console.log("internalModuleReadFile", path);
     var entity = VIRTUAL_FILESYSTEM[path];
-    if (!entity) return undefined;
+    if (!entity) return [undefined, undefined];
     var entityContent = entity[STORE_CONTENT];
-    if (!entityContent) return undefined;
-    return payloadFileSync(entityContent).toString();
+    if (!entityContent) return [undefined, undefined];
+    return [payloadFileSync(entityContent).toString(), true];
   };
 }());
 


### PR DESCRIPTION
The PR is inspired by https://github.com/vercel/pkg-fetch/pull105#issuecomment-757116069

This is a pre-requisite for updating to newer Node.js version (currently supports only v12, v14 and for future usage >=v15). The change should preserver backward-compatibility.

Related: #1008 https://github.com/vercel/pkg-fetch/issues/114

