### PR TITLE
Add support for symlink and pnpm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,3 +311,26 @@ You could check on **Unix systems** (Linux/macOS) in `bash`:
 ```bash
 $ printenv | grep NODE
 ```
+
+## Advanced
+
+### exploring virtual file system embedded in debug mode
+
+When you are using the `--debug` flag when building your executable,
+`pkg` add the ability to display the content of the virtual file system
+and the symlink table on the console, when the application starts,
+providing that the environement variable DEBUG_PKG is set.
+This feature can be useful to inspect if symlinks are correctly handled,
+and check that all the required files for your application are properly
+incorporated to the final executable.
+
+    $ pkg --debug app.js -o output
+    $ DEBUG_PKG output
+
+or
+
+    C:\> pkg --debug app.js -o output.exe
+    C:\> set DEBUG_PKG=1
+    C:\> output.exe
+
+Note: make sure not to use --debug flag in production.

--- a/lib/follow.js
+++ b/lib/follow.js
@@ -2,6 +2,7 @@ import { core, sync } from 'resolve';
 import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
+import { toNormalizedRealPath } from '../prelude/common';
 
 Object.keys(core).forEach((key) => {
   // 'resolve' hardcodes the list to host's one, but i need
@@ -77,6 +78,13 @@ export function follow(x, opts) {
         packageFilter: (config, base) => {
           if (opts.packageFilter) opts.packageFilter(config, base);
           return config;
+        },
+
+        /** function to synchronously resolve a potential symlink to its real path */
+        // realpathSync?: (file: string) => string;
+        realpathSync: (file) => {
+          const file2 = toNormalizedRealPath(file);
+          return file2;
         },
       })
     );

--- a/lib/index.js
+++ b/lib/index.js
@@ -313,8 +313,7 @@ export async function exec(argv2) {
     if (!outputPath) {
       if (inputJson && inputJson.pkg) {
         outputPath = inputJson.pkg.outputPath;
-      } else
-      if (configJson && configJson.pkg) {
+      } else if (configJson && configJson.pkg) {
         outputPath = configJson.pkg.outputPath;
       }
       outputPath = outputPath || '';
@@ -467,17 +466,20 @@ export async function exec(argv2) {
 
   let records;
   let entrypoint = inputFin;
+  let symLinks;
   const addition = isConfiguration(input) ? input : undefined;
 
   const walkResult = await walk(marker, entrypoint, addition, params);
   entrypoint = walkResult.entrypoint;
   records = walkResult.records;
+  symLinks = walkResult.symLinks;
 
-  const refineResult = refine(records, entrypoint);
+  const refineResult = refine(records, entrypoint, symLinks);
   entrypoint = refineResult.entrypoint;
   records = refineResult.records;
+  symLinks = refineResult.symLinks;
 
-  const backpack = packer({ records, entrypoint, bytecode });
+  const backpack = packer({ records, entrypoint, bytecode, symLinks });
 
   log.debug('Targets:', JSON.stringify(targets, null, 2));
 
@@ -495,7 +497,7 @@ export async function exec(argv2) {
     }
 
     const slash = target.platform === 'win' ? '\\' : '/';
-    await producer({ backpack, bakes, slash, target });
+    await producer({ backpack, bakes, slash, target, symLinks });
     if (target.platform !== 'win') {
       await plusx(target.output);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -471,6 +471,7 @@ export async function exec(argv2) {
 
   const walkResult = await walk(marker, entrypoint, addition, params);
   entrypoint = walkResult.entrypoint;
+
   records = walkResult.records;
   symLinks = walkResult.symLinks;
 

--- a/lib/packer.js
+++ b/lib/packer.js
@@ -24,6 +24,11 @@ const commonText = fs.readFileSync(
   'utf8'
 );
 
+const diagnosticText = fs.readFileSync(
+  require.resolve('../prelude/diagnostic.js'),
+  'utf8'
+);
+
 function itemsToText(items) {
   const len = items.length;
   return len.toString() + (len % 10 === 1 ? ' item' : ' items');
@@ -48,12 +53,14 @@ export default function packer({ records, entrypoint, bytecode }) {
       assert(record[STORE_STAT], 'packer: no STORE_STAT');
 
       assert(
-        record[STORE_BLOB] || record[STORE_CONTENT] || record[STORE_LINKS]
+        record[STORE_BLOB] ||
+          record[STORE_CONTENT] ||
+          record[STORE_LINKS] ||
+          record[STORE_STAT]
       );
 
       if (record[STORE_BLOB] && !bytecode) {
         delete record[STORE_BLOB];
-
         if (!record[STORE_CONTENT]) {
           // TODO make a test for it?
           throw wasReported(
@@ -66,7 +73,6 @@ export default function packer({ records, entrypoint, bytecode }) {
           );
         }
       }
-
       for (const store of [
         STORE_BLOB,
         STORE_CONTENT,
@@ -88,68 +94,54 @@ export default function packer({ records, entrypoint, bytecode }) {
           }
         } else if (store === STORE_LINKS) {
           if (Array.isArray(value)) {
-            const buffer = Buffer.from(JSON.stringify(value));
+            const dedupedValue = [...new Set(value)];
+            log.debug('files & folders deduped = ', dedupedValue);
+            const buffer = Buffer.from(JSON.stringify(dedupedValue));
             stripes.push({ snap, store, buffer });
           } else {
             assert(false, 'packer: bad STORE_LINKS');
           }
         } else if (store === STORE_STAT) {
           if (typeof value === 'object') {
-            // reproducible
-            delete value.atime;
-            delete value.atimeMs;
-            delete value.mtime;
-            delete value.mtimeMs;
-            delete value.ctime;
-            delete value.ctimeMs;
-            delete value.birthtime;
-            delete value.birthtimeMs;
-            // non-date
-            delete value.blksize;
-            delete value.blocks;
-            delete value.dev;
-            delete value.gid;
-            delete value.ino;
-            delete value.nlink;
-            delete value.rdev;
-            delete value.uid;
-            if (!value.isFile()) value.size = 0;
-            // portable
             const newStat = { ...value };
-            newStat.isFileValue = value.isFile();
-            newStat.isDirectoryValue = value.isDirectory();
-            newStat.isSocketValue = value.isSocket();
             const buffer = Buffer.from(JSON.stringify(newStat));
             stripes.push({ snap, store, buffer });
           } else {
-            assert(false, 'packer: bad STORE_STAT');
+            assert(false, 'packer: unknown store');
           }
-        } else {
-          assert(false, 'packer: unknown store');
         }
-      }
 
-      if (record[STORE_CONTENT]) {
-        const disclosed = isDotJS(file) || isDotJSON(file);
-        log.debug(
-          disclosed
-            ? 'The file was included as DISCLOSED code (with sources)'
-            : 'The file was included as asset content',
-          file
-        );
-      } else if (record[STORE_BLOB]) {
-        log.debug('The file was included as bytecode (no sources)', file);
-      } else if (record[STORE_LINKS]) {
-        const value = record[STORE_LINKS];
-        log.debug(
-          `The directory files list was included (${itemsToText(value)})`,
-          file
-        );
+        if (record[STORE_CONTENT]) {
+          const disclosed = isDotJS(file) || isDotJSON(file);
+          log.debug(
+            disclosed
+              ? 'The file was included as DISCLOSED code (with sources)'
+              : 'The file was included as asset content',
+            file
+          );
+        } else if (record[STORE_BLOB]) {
+          log.debug('The file was included as bytecode (no sources)', file);
+        } else if (record[STORE_LINKS]) {
+          const link = record[STORE_LINKS];
+          log.debug(
+            `The directory files list was included (${itemsToText(link)})`,
+            file
+          );
+        }
       }
     }
   }
-
-  const prelude = `return (function (REQUIRE_COMMON, VIRTUAL_FILESYSTEM, DEFAULT_ENTRYPOINT) { ${bootstrapText}\n})(function (exports) {\n${commonText}\n},\n${'%VIRTUAL_FILESYSTEM%'}\n,\n${'%DEFAULT_ENTRYPOINT%'}\n);`;
+  const prelude =
+    `return (function (REQUIRE_COMMON, VIRTUAL_FILESYSTEM, DEFAULT_ENTRYPOINT, SYMLINKS) { 
+        ${bootstrapText}${
+      log.debugMode ? diagnosticText : ''
+    }\n})(function (exports) {\n${commonText}\n},\n` +
+    `%VIRTUAL_FILESYSTEM%` +
+    `\n,\n` +
+    `%DEFAULT_ENTRYPOINT%` +
+    `\n,\n` +
+    `%SYMLINKS%` +
+    `\n);`;
 
   return { prelude, entrypoint, stripes };
 }

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -166,7 +166,7 @@ function nativePrebuildInstall(target, nodeFile) {
   return nativeFile;
 }
 
-export default function producer({ backpack, bakes, slash, target }) {
+export default function producer({ backpack, bakes, slash, target, symLinks }) {
   return new Promise((resolve, reject) => {
     if (!Buffer.alloc) {
       throw wasReported(
@@ -186,6 +186,12 @@ export default function producer({ backpack, bakes, slash, target }) {
       if (!vfs[snap]) vfs[snap] = {};
     }
 
+    const snapshotSymLinks = {};
+    for (const [key, value] of Object.entries(symLinks)) {
+      const k = snapshotify(key, slash);
+      const v = snapshotify(value, slash);
+      snapshotSymLinks[k] = v;
+    }
     let meter;
     let count = 0;
 
@@ -300,12 +306,16 @@ export default function producer({ backpack, bakes, slash, target }) {
                 makePreludeBufferFromPrelude(
                   replaceDollarWise(
                     replaceDollarWise(
-                      prelude,
-                      '%VIRTUAL_FILESYSTEM%',
-                      JSON.stringify(vfs)
+                      replaceDollarWise(
+                        prelude,
+                        '%VIRTUAL_FILESYSTEM%',
+                        JSON.stringify(vfs)
+                      ),
+                      '%DEFAULT_ENTRYPOINT%',
+                      JSON.stringify(entrypoint)
                     ),
-                    '%DEFAULT_ENTRYPOINT%',
-                    JSON.stringify(entrypoint)
+                    '%SYMLINKS%',
+                    JSON.stringify(snapshotSymLinks)
                   )
                 )
               )

--- a/lib/refiner.js
+++ b/lib/refiner.js
@@ -62,8 +62,8 @@ function denominate(records, entrypoint, denominator, symLinks) {
 
     return snap;
   };
+  // eslint-disable-next-line guard-for-in
   for (const file in records) {
-    // eslint-disable-line guard-for-in
     const snap = makeSnap(file);
     newRecords[snap] = records[file];
   }

--- a/lib/refiner.js
+++ b/lib/refiner.js
@@ -1,9 +1,11 @@
 import path from 'path';
+import chalk from 'chalk';
 import {
   STORE_LINKS,
   retrieveDenominator,
   substituteDenominator,
 } from '../prelude/common';
+import { log } from './log';
 
 const win32 = process.platform === 'win32';
 
@@ -22,7 +24,6 @@ function purgeTopDirectories(records) {
       if (records[file]) {
         const record = records[file];
         const links = record[STORE_LINKS];
-
         if (links && links.length === 1) {
           if (!hasParent(file, records)) {
             const file2 = path.join(file, links[0]);
@@ -33,8 +34,8 @@ function purgeTopDirectories(records) {
               const record3 = records[file3];
               const links3 = record3[STORE_LINKS];
               if (links3) {
-                // eslint-disable-next-line no-param-reassign
                 delete records[file];
+                log.debug(chalk.cyan('Deleting record file :', file));
                 found = true;
               }
             }
@@ -47,31 +48,41 @@ function purgeTopDirectories(records) {
   }
 }
 
-function denominate(records, entrypoint, denominator) {
+function denominate(records, entrypoint, denominator, symLinks) {
   const newRecords = {};
 
-  for (const file in records) {
-    if (records[file]) {
-      let snap = substituteDenominator(file, denominator);
+  const makeSnap = (file) => {
+    let snap = substituteDenominator(file, denominator);
 
-      if (win32) {
-        if (snap.slice(1) === ':') snap += '\\';
-      } else if (snap === '') {
-        snap = '/';
-      }
-
-      newRecords[snap] = records[file];
+    if (win32) {
+      if (snap.slice(1) === ':') snap += '\\';
+    } else if (snap === '') {
+      snap = '/';
     }
-  }
 
+    return snap;
+  };
+  for (const file in records) {
+    // eslint-disable-line guard-for-in
+    const snap = makeSnap(file);
+    newRecords[snap] = records[file];
+  }
+  const tmpSymLinks = symLinks;
+  symLinks = {};
+  for (const [key, value] of Object.entries(tmpSymLinks)) {
+    const key1 = makeSnap(key);
+    const value1 = makeSnap(value);
+    symLinks[key1] = value1;
+  }
   return {
     records: newRecords,
     entrypoint: substituteDenominator(entrypoint, denominator),
+    symLinks,
   };
 }
 
-export default function refiner(records, entrypoint) {
+export default function refiner(records, entrypoint, symLinks) {
   purgeTopDirectories(records);
   const denominator = retrieveDenominator(Object.keys(records));
-  return denominate(records, entrypoint, denominator);
+  return denominate(records, entrypoint, denominator, symLinks);
 }

--- a/lib/walker.js
+++ b/lib/walker.js
@@ -4,6 +4,7 @@ import assert from 'assert';
 import fs from 'fs-extra';
 import globby from 'globby';
 import path from 'path';
+import chalk from 'chalk';
 
 import {
   ALIAS_AS_RELATIVE,
@@ -17,12 +18,20 @@ import {
   isDotNODE,
   isPackageJson,
   normalizePath,
+  toNormalizedRealPath,
 } from '../prelude/common';
 
 import { follow, natives } from './follow';
 import { log, wasReported } from './log';
-import * as detector from './detector';
+import {
+  detect,
+  visitor_MALFORMED,
+  visitor_NONLITERAL,
+  visitor_USESCWD,
+  visitor_SUCCESSFUL,
+} from './detector';
 
+const strictVerify = Boolean(process.env.PKG_STRICT_VER);
 const win32 = process.platform === 'win32';
 
 function unlikelyJavascript(file) {
@@ -119,14 +128,28 @@ class Walker {
   appendRecord(task) {
     const { file } = task;
     if (this.records[file]) return;
+
+    if (
+      task.store === STORE_BLOB ||
+      task.store === STORE_CONTENT ||
+      task.store === STORE_LINKS
+    ) {
+      // make sure we have a real file
+      if (strictVerify) {
+        assert(task.file === toNormalizedRealPath(task.file));
+      }
+    }
     this.records[file] = { file };
   }
 
+  /** @private */
   append(task) {
-    task.file = normalizePath(task.file);
+    if (strictVerify) {
+      assert(typeof task.file === 'string');
+      assert(task.file === normalizePath(task.file));
+    }
     this.appendRecord(task);
     this.tasks.push(task);
-
     const what = {
       [STORE_BLOB]: 'Bytecode of',
       [STORE_CONTENT]: 'Content of',
@@ -134,13 +157,99 @@ class Walker {
       [STORE_STAT]: 'Stat info of',
     }[task.store];
     if (task.reason) {
-      log.debug(`${what}  %1 is added to queue. It was required from %2`, [
-        `%1: ${task.file}`,
-        `%2: ${task.reason}`,
-      ]);
+      log.debug(
+        `${what} ${task.file} is added to queue. It was required from ${task.reason}`
+      );
     } else {
-      log.debug(`${what} %1 is added to queue`, [`%1: ${task.file}`]);
+      log.debug(`${what} ${task.file} is added to queue.`);
     }
+  }
+
+  findCommonJunctionPoint(file, realFile) {
+    // find common denominator => where the link changes
+    while (
+      toNormalizedRealPath(path.dirname(file)) === path.dirname(realFile)
+    ) {
+      file = path.dirname(file);
+      realFile = path.dirname(realFile);
+    }
+    return { file, realFile };
+  }
+
+  appendSymlink(file, realFile) {
+    const a = this.findCommonJunctionPoint(file, realFile);
+    file = a.file;
+    realFile = a.realFile;
+    if (!this.symLinks[file]) {
+      const dn = path.dirname(file);
+      this.appendFileInFolder({
+        file: dn,
+        store: STORE_LINKS,
+        data: path.basename(file),
+      });
+
+      log.debug(`adding symlink ${file}  => ${path.relative(file, realFile)}`);
+      this.symLinks[file] = realFile;
+
+      this.appendStat({
+        file: realFile,
+        store: STORE_STAT,
+      });
+      this.appendStat({
+        file: dn,
+        store: STORE_STAT,
+      });
+      this.appendStat({
+        file,
+        store: STORE_STAT,
+      });
+    }
+  }
+
+  appendStat(task) {
+    assert(task.store === STORE_STAT);
+    this.append(task);
+  }
+
+  appendFileInFolder(task) {
+    if (strictVerify) {
+      assert(task.store === STORE_LINKS);
+      assert(typeof task.file === 'string');
+    }
+    const realFile = toNormalizedRealPath(task.file);
+    if (realFile === task.file) {
+      this.append(task);
+      return;
+    }
+    this.append({ ...task, file: realFile });
+    this.appendStat({
+      file: task.file,
+      store: STORE_STAT,
+    });
+    this.appendStat({
+      file: path.dirname(task.file),
+      store: STORE_STAT,
+    });
+  }
+
+  appendBlobOrContent(task) {
+    if (strictVerify) {
+      assert(task.file === normalizePath(task.file));
+    }
+    assert(task.store === STORE_BLOB || task.store === STORE_CONTENT);
+    assert(typeof task.file === 'string');
+    const realFile = toNormalizedRealPath(task.file);
+    if (realFile === task.file) {
+      this.append(task);
+      return;
+    }
+
+    this.append({ ...task, file: realFile });
+    this.appendSymlink(task.file, realFile);
+    this.appendStat({
+      file: task.file,
+      store: STORE_STAT,
+    });
   }
 
   async appendFilesFromConfig(marker) {
@@ -162,8 +271,8 @@ class Walker {
               ]);
             }
 
-            this.append({
-              file: script,
+            this.appendBlobOrContent({
+              file: normalizePath(script),
               marker,
               store: STORE_BLOB,
               reason: configPath,
@@ -179,8 +288,8 @@ class Walker {
         for (const asset of assets) {
           const stat = await fs.stat(asset);
           if (stat.isFile()) {
-            this.append({
-              file: asset,
+            this.appendBlobOrContent({
+              file: normalizePath(asset),
               marker,
               store: STORE_CONTENT,
               reason: configPath,
@@ -193,21 +302,22 @@ class Walker {
 
       if (files) {
         files = expandFiles(files, base);
-        for (const file of files) {
+        for (let file of files) {
+          file = normalizePath(file);
           const stat = await fs.stat(file);
           if (stat.isFile()) {
             // 1) remove sources of top-level(!) package 'files' i.e. ship as BLOB
             // 2) non-source (non-js) files of top-level package are shipped as CONTENT
             // 3) parsing some js 'files' of non-top-level packages fails, hence all CONTENT
             if (marker.toplevel) {
-              this.append({
+              this.appendBlobOrContent({
                 file,
                 marker,
                 store: isDotJS(file) ? STORE_BLOB : STORE_CONTENT,
                 reason: configPath,
               });
             } else {
-              this.append({
+              this.appendBlobOrContent({
                 file,
                 marker,
                 store: STORE_CONTENT,
@@ -313,8 +423,10 @@ class Walker {
   }
 
   async stepRead(record) {
+    if (strictVerify) {
+      assert(record.file === toNormalizedRealPath(record.file));
+    }
     let body;
-
     try {
       body = await fs.readFile(record.file);
     } catch (error) {
@@ -375,16 +487,16 @@ class Walker {
     const { body } = record;
 
     try {
-      detector.detect(body, (node, trying) => {
+      detect(body, (node, trying) => {
         const { toplevel } = marker;
-        let d = detector.visitor_SUCCESSFUL(node);
+        let d = visitor_SUCCESSFUL(node);
         if (d) {
           if (d.mustExclude) return false;
           d.mayExclude = d.mayExclude || trying;
           derivatives.push(d);
           return false;
         }
-        d = detector.visitor_NONLITERAL(node);
+        d = visitor_NONLITERAL(node);
         if (d) {
           if (d.mustExclude) return false;
           const debug = !toplevel || d.mayExclude || trying;
@@ -398,7 +510,7 @@ class Walker {
           ]);
           return false;
         }
-        d = detector.visitor_MALFORMED(node);
+        d = visitor_MALFORMED(node);
         if (d) {
           // there is no 'mustExclude'
           const debug = !toplevel || trying;
@@ -406,7 +518,7 @@ class Walker {
           log[level](`Malformed requirement for '${d.alias}'`, [record.file]);
           return false;
         }
-        d = detector.visitor_USESCWD(node);
+        d = visitor_USESCWD(node);
         if (d) {
           // there is no 'mustExclude'
           const level = 'debug'; // there is no 'mayExclude'
@@ -427,7 +539,8 @@ class Walker {
 
   async stepDerivatives_ALIAS_AS_RELATIVE(record, marker, derivative) {
     // eslint-disable-line camelcase
-    const file = path.join(path.dirname(record.file), derivative.alias);
+    let file = path.join(path.dirname(record.file), derivative.alias);
+    file = normalizePath(file);
 
     let stat;
 
@@ -444,7 +557,7 @@ class Walker {
     }
 
     if (stat && stat.isFile()) {
-      this.append({
+      this.appendBlobOrContent({
         file,
         marker,
         store: STORE_CONTENT,
@@ -470,9 +583,10 @@ class Walker {
     let newFile;
     let failure;
 
+    const basedir = path.dirname(record.file);
     try {
       newFile = await follow(derivative.alias, {
-        basedir: path.dirname(record.file),
+        basedir,
         // default is extensions: ['.js'], but
         // it is not enough because 'typos.json'
         // is not taken in require('./typos')
@@ -501,7 +615,7 @@ class Walker {
           `%2: ${record.file}`,
         ]);
       } else {
-        log[level](failure.message, [`%1: ${record.file}`]);
+        log[level](`${chalk.yellow(failure.message)}  in ${record.file}`);
       }
       return;
     }
@@ -517,6 +631,9 @@ class Walker {
           extensions: ['.js', '.json', '.node'],
           ignoreFile: newPackage.packageJson,
         });
+        if (strictVerify) {
+          assert(newFile2 === normalizePath(newFile2));
+        }
       } catch (_) {
         // not setting is enough
       }
@@ -528,7 +645,13 @@ class Walker {
     }
 
     if (newPackageForNewRecords) {
-      this.append({
+      if (strictVerify) {
+        assert(
+          newPackageForNewRecords.packageJson ===
+            normalizePath(newPackageForNewRecords.packageJson)
+        );
+      }
+      this.appendBlobOrContent({
         file: newPackageForNewRecords.packageJson,
         marker: newPackageForNewRecords.marker,
         store: STORE_CONTENT,
@@ -536,7 +659,7 @@ class Walker {
       });
     }
 
-    this.append({
+    this.appendBlobOrContent({
       file: newFile,
       marker: newPackageForNewRecords ? newPackageForNewRecords.marker : marker,
       store: STORE_BLOB,
@@ -548,30 +671,36 @@ class Walker {
     for (const derivative of derivatives) {
       if (natives[derivative.alias]) continue;
 
-      if (derivative.aliasType === ALIAS_AS_RELATIVE) {
-        await this.stepDerivatives_ALIAS_AS_RELATIVE(
-          record,
-          marker,
-          derivative
-        );
-      } else if (derivative.aliasType === ALIAS_AS_RESOLVABLE) {
-        await this.stepDerivatives_ALIAS_AS_RESOLVABLE(
-          record,
-          marker,
-          derivative
-        );
-      } else {
-        assert(false, `walker: unknown aliasType ${derivative.aliasType}`);
+      switch (derivative.aliasType) {
+        case ALIAS_AS_RELATIVE:
+          await this.stepDerivatives_ALIAS_AS_RELATIVE(
+            record,
+            marker,
+            derivative
+          );
+          break;
+        case ALIAS_AS_RESOLVABLE:
+          await this.stepDerivatives_ALIAS_AS_RESOLVABLE(
+            record,
+            marker,
+            derivative
+          );
+          break;
+        default:
+          assert(false, `walker: unknown aliasType ${derivative.aliasType}`);
       }
     }
   }
 
   async step_STORE_ANY(record, marker, store) {
     // eslint-disable-line camelcase
+    if (strictVerify) {
+      assert(record.file === toNormalizedRealPath(record.file));
+    }
     if (record[store] !== undefined) return;
     record[store] = false; // default is discard
 
-    this.append({
+    this.appendStat({
       file: record.file,
       store: STORE_STAT,
     });
@@ -581,7 +710,7 @@ class Walker {
     await this.stepDerivatives(record, marker, derivatives1);
     if (store === STORE_BLOB) {
       if (unlikelyJavascript(record.file) || isDotNODE(record.file)) {
-        this.append({
+        this.appendBlobOrContent({
           file: record.file,
           marker,
           store: STORE_CONTENT,
@@ -590,7 +719,7 @@ class Walker {
       }
 
       if (marker.public || marker.hasDictionary) {
-        this.append({
+        this.appendBlobOrContent({
           file: record.file,
           marker,
           store: STORE_CONTENT,
@@ -619,6 +748,12 @@ class Walker {
 
   step_STORE_LINKS(record, data) {
     // eslint-disable-line camelcase
+    if (strictVerify) {
+      assert(
+        record.file === toNormalizedRealPath(record.file),
+        ' expecting real file !!!'
+      );
+    }
     if (record[STORE_LINKS]) {
       record[STORE_LINKS].push(data);
       return;
@@ -626,7 +761,10 @@ class Walker {
 
     record[STORE_LINKS] = [data];
 
-    this.append({
+    if (record[STORE_STAT]) {
+      return;
+    }
+    this.appendStat({
       file: record.file,
       store: STORE_STAT,
     });
@@ -636,8 +774,27 @@ class Walker {
     // eslint-disable-line camelcase
     if (record[STORE_STAT]) return;
 
+    const realPath = toNormalizedRealPath(record.file);
+    if (realPath !== record.file) {
+      this.appendStat({
+        file: realPath,
+        store: STORE_STAT,
+      });
+    }
+
     try {
-      record[STORE_STAT] = await fs.stat(record.file);
+      const valueStat = await fs.stat(record.file);
+
+      const value = {
+        mode: valueStat.mode,
+        size: valueStat.isFile() ? valueStat.size : 0,
+        //
+        isFileValue: valueStat.isFile(),
+        isDirectoryValue: valueStat.isDirectory(),
+        isSocketValue: valueStat.isSocket(),
+        isSymbolicLinkValue: valueStat.isSymbolicLink(),
+      };
+      record[STORE_STAT] = value;
     } catch (error) {
       log.error(`Cannot stat, ${error.code}`, record.file);
       throw wasReported(error);
@@ -645,7 +802,7 @@ class Walker {
 
     if (path.dirname(record.file) !== record.file) {
       // root directory
-      this.append({
+      this.appendFileInFolder({
         file: path.dirname(record.file),
         store: STORE_LINKS,
         data: path.basename(record.file),
@@ -656,14 +813,19 @@ class Walker {
   async step(task) {
     const { file, store, data } = task;
     const record = this.records[file];
-    if (store === STORE_BLOB || store === STORE_CONTENT) {
-      await this.step_STORE_ANY(record, task.marker, store);
-    } else if (store === STORE_LINKS) {
-      this.step_STORE_LINKS(record, data);
-    } else if (store === STORE_STAT) {
-      await this.step_STORE_STAT(record);
-    } else {
-      assert(false, `walker: unknown store ${store}`);
+    switch (store) {
+      case STORE_BLOB:
+      case STORE_CONTENT:
+        await this.step_STORE_ANY(record, task.marker, store);
+        break;
+      case STORE_LINKS:
+        this.step_STORE_LINKS(record, data);
+        break;
+      case STORE_STAT:
+        await this.step_STORE_STAT(record);
+        break;
+      default:
+        assert(false, `walker: unknown store ${store}`);
     }
   }
 
@@ -699,17 +861,21 @@ class Walker {
     this.dictionary = {};
     this.patches = {};
     this.params = params;
+    this.symLinks = {};
 
     await this.readDictionary(marker);
 
-    this.append({
+    entrypoint = normalizePath(entrypoint);
+
+    this.appendBlobOrContent({
       file: entrypoint,
       marker,
       store: STORE_BLOB,
     });
 
     if (addition) {
-      this.append({
+      addition = normalizePath(addition);
+      this.appendBlobOrContent({
         file: addition,
         marker,
         store: STORE_CONTENT,
@@ -725,6 +891,7 @@ class Walker {
     }
 
     return {
+      symLinks: this.symLinks,
       records: this.records,
       entrypoint: normalizePath(entrypoint),
     };

--- a/lib/walker.js
+++ b/lib/walker.js
@@ -31,7 +31,15 @@ import {
   visitor_SUCCESSFUL,
 } from './detector';
 
+// Note: as a developer, you can set the PKG_STRICT_VER variable.
+//       this will turn on some assertion in the walker code below
+//       to assert that each file content/state that we appending
+//       to the virtual file system applies to  a real file,
+//       not a symlink.
+//       By default assertion are disabled as they can have a
+//       performance hit.
 const strictVerify = Boolean(process.env.PKG_STRICT_VER);
+
 const win32 = process.platform === 'win32';
 
 function unlikelyJavascript(file) {
@@ -788,7 +796,6 @@ class Walker {
       const value = {
         mode: valueStat.mode,
         size: valueStat.isFile() ? valueStat.size : 0,
-        //
         isFileValue: valueStat.isFile(),
         isDirectoryValue: valueStat.isDirectory(),
         isSocketValue: valueStat.isSocket(),

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -14,8 +14,12 @@
 /* global REQUIRE_COMMON */
 /* global VIRTUAL_FILESYSTEM */
 /* global DEFAULT_ENTRYPOINT */
+/* global SYMLINKS */
 
 'use strict';
+
+const { normalize } = require('path');
+const assert = require('assert');
 
 var common = {};
 REQUIRE_COMMON(common);
@@ -161,6 +165,33 @@ console.log(translateNth(["", "r+"], 0, "d:\\snapshot\\countly\\plugins-ext"));
 console.log(translateNth(["", "rw"], 0, "d:\\snapshot\\countly\\plugins-ext\\"));
 console.log(translateNth(["", "a+"], 0, "d:\\snapshot\\countly\\plugins-ext\\1234"));
 */
+
+const win32 = process.platform === 'win32';
+const slash = win32 ? '\\' : '/';
+function realpathFromSnapshot(path_) {
+  path_ = normalize(path_);
+  let count = 0;
+  let needToSubstitute = true;
+  while (needToSubstitute) {
+    needToSubstitute = false;
+    for (const [k, v] of Object.entries(SYMLINKS)) {
+      if (path_.startsWith(k + slash) || path_ === k) {
+        path_ = path_.replace(k, v);
+        needToSubstitute = true;
+        break;
+      }
+    }
+    count += 1;
+  }
+  assert(count === 1 || count === 2);
+  return path_;
+}
+
+function normalizePathAndFollowLink(path_) {
+  path_ = normalizePath(path_);
+  var path = realpathFromSnapshot(path_);
+  return path;
+}
 
 // /////////////////////////////////////////////////////////////////
 // PROJECT /////////////////////////////////////////////////////////
@@ -481,8 +512,7 @@ function payloadFileSync(pointer) {
 
   function openFromSnapshot(path_, cb) {
     var cb2 = cb || rethrow;
-    var path = normalizePath(path_);
-    // console.log("openFromSnapshot", path);
+    var path = normalizePathAndFollowLink(path_);
     var entity = VIRTUAL_FILESYSTEM[path];
     if (!entity) return cb2(error_ENOENT('File or directory', path));
     var dock = { path, entity, position: 0 };
@@ -724,7 +754,6 @@ function payloadFileSync(pointer) {
   function readFileFromSnapshot(path_, cb) {
     var cb2 = cb || rethrow;
     var path = normalizePath(path_);
-    // console.log("readFileFromSnapshot", path);
     var entity = VIRTUAL_FILESYSTEM[path];
     if (!entity) return cb2(error_ENOENT('File', path));
     var entityLinks = entity[STORE_LINKS];
@@ -837,13 +866,14 @@ function payloadFileSync(pointer) {
     return this.type === 1;
   };
 
-  Dirent.prototype.isSocket = function isSocket() {
-    return false;
-  };
-  Dirent.prototype.isFIFO = Dirent.prototype.isSocket;
-  Dirent.prototype.isSymbolicLink = Dirent.prototype.isSocket;
-  Dirent.prototype.isCharacterDevice = Dirent.prototype.isSocket;
-  Dirent.prototype.isBlockDevice = Dirent.prototype.isSocket;
+  const noop = () => false;
+  Dirent.prototype.isBlockDevice = noop;
+  Dirent.prototype.isCharacterDevice = noop;
+  Dirent.prototype.isSocket = noop;
+  Dirent.prototype.isFIFO = noop;
+
+  Dirent.prototype.isSymbolicLink = (fileOrFolderName) =>
+    Boolean(SYMLINKS[fileOrFolderName]);
 
   function getFileTypes(path_, entries) {
     return entries.map((entry) => {
@@ -885,8 +915,9 @@ function payloadFileSync(pointer) {
   function readdirFromSnapshot(path_, isRoot, cb) {
     var cb2 = cb || rethrow;
     if (isRoot) return readdirRoot(path_, cb);
-    var path = normalizePath(path_);
-    // console.log("readdirFromSnapshot", path);
+
+    var path = normalizePathAndFollowLink(path_);
+
     var entity = VIRTUAL_FILESYSTEM[path];
     if (!entity) return cb2(error_ENOENT('Directory', path));
     var entityBlob = entity[STORE_BLOB];
@@ -947,12 +978,6 @@ function payloadFileSync(pointer) {
   // realpath //////////////////////////////////////////////////////
   // ///////////////////////////////////////////////////////////////
 
-  function realpathFromSnapshot(path_) {
-    var path = normalizePath(path_);
-    // console.log("realpathFromSnapshot", path);
-    return path;
-  }
-
   fs.realpathSync = function realpathSync(path) {
     if (!insideSnapshot(path)) {
       return ancestor.realpathSync.apply(fs, arguments);
@@ -1000,12 +1025,15 @@ function payloadFileSync(pointer) {
     s.ctimeMs = EXECSTAT.ctimeMs;
     s.birthtimeMs = EXECSTAT.birthtimeMs;
 
-    var { isFileValue } = s;
-    var { isDirectoryValue } = s;
-    var { isSocketValue } = s;
+    const { isFileValue } = s;
+    const { isDirectoryValue } = s;
+    const { isSocketValue } = s;
+    const { isSymbolicLinkValue } = s;
+
     delete s.isFileValue;
     delete s.isDirectoryValue;
     delete s.isSocketValue;
+    delete s.isSymbolicLinkValue;
 
     s.isFile = function isFile() {
       return isFileValue;
@@ -1017,7 +1045,7 @@ function payloadFileSync(pointer) {
       return isSocketValue;
     };
     s.isSymbolicLink = function isSymbolicLink() {
-      return false;
+      return isSymbolicLinkValue;
     };
     s.isFIFO = function isFIFO() {
       return false;
@@ -1051,8 +1079,7 @@ function payloadFileSync(pointer) {
 
   function statFromSnapshot(path_, cb) {
     var cb2 = cb || rethrow;
-    var path = normalizePath(path_);
-    // console.log("statFromSnapshot", path);
+    var path = normalizePathAndFollowLink(path_);
     var entity = VIRTUAL_FILESYSTEM[path];
     if (!entity) return findNativeAddonForStat(path, cb);
     var entityStat = entity[STORE_STAT];
@@ -1150,8 +1177,7 @@ function payloadFileSync(pointer) {
   }
 
   function existsFromSnapshot(path_) {
-    var path = normalizePath(path_);
-    // console.log("existsFromSnapshot", path);
+    var path = normalizePathAndFollowLink(path_);
     var entity = VIRTUAL_FILESYSTEM[path];
     if (!entity) return findNativeAddonForExists(path);
     return true;
@@ -1186,8 +1212,7 @@ function payloadFileSync(pointer) {
 
   function accessFromSnapshot(path_, cb) {
     var cb2 = cb || rethrow;
-    var path = normalizePath(path_);
-    // console.log("accessFromSnapshot", path);
+    var path = normalizePathAndFollowLink(path_);
     var entity = VIRTUAL_FILESYSTEM[path];
     if (!entity) return cb2(error_ENOENT('File or directory', path));
     return cb2(null, undefined);
@@ -1270,8 +1295,7 @@ function payloadFileSync(pointer) {
         .internalModuleStat(makeLong(translate(path)));
     }
 
-    path = normalizePath(path);
-    // console.log("internalModuleStat", path);
+    path = normalizePathAndFollowLink(path);
     var entity = VIRTUAL_FILESYSTEM[path];
     if (!entity) return findNativeAddonForInternalModuleStat(path);
     var entityBlob = entity[STORE_BLOB];
@@ -1291,14 +1315,14 @@ function payloadFileSync(pointer) {
     // For newer node versions (after https://github.com/nodejs/node/pull/33229 ):
     // Returns an array [string, boolean].
     //
-    var returnArray =
+    const returnArray =
       (NODE_VERSION_MAJOR === 12 && NODE_VERSION_MINOR >= 19) ||
       (NODE_VERSION_MAJOR === 14 && NODE_VERSION_MINOR >= 5) ||
       NODE_VERSION_MAJOR >= 15;
 
-    var path = revertMakingLong(long);
-    var bindingFs = process.binding('fs');
-    var readFile = (
+    const path = revertMakingLong(long);
+    const bindingFs = process.binding('fs');
+    const readFile = (
       bindingFs.internalModuleReadFile || bindingFs.internalModuleReadJSON
     ).bind(bindingFs);
     if (!insideSnapshot(path)) {
@@ -1308,11 +1332,10 @@ function payloadFileSync(pointer) {
       return readFile(makeLong(translate(path)));
     }
 
-    path = normalizePath(path);
-    // console.log("internalModuleReadFile", path);
-    var entity = VIRTUAL_FILESYSTEM[path];
+    const path2 = normalizePathAndFollowLink(path);
+    const entity = VIRTUAL_FILESYSTEM[path2];
     if (!entity) return returnArray ? [undefined, false] : undefined;
-    var entityContent = entity[STORE_CONTENT];
+    const entityContent = entity[STORE_CONTENT];
     if (!entityContent) return returnArray ? [undefined, false] : undefined;
     return returnArray
       ? [payloadFileSync(entityContent).toString(), true]
@@ -1398,8 +1421,7 @@ function payloadFileSync(pointer) {
       return ancestor._compile.apply(this, arguments);
     }
 
-    var filename = normalizePath(filename_);
-    // console.log("_compile", filename);
+    var filename = normalizePathAndFollowLink(filename_);
     var entity = VIRTUAL_FILESYSTEM[filename];
 
     if (!entity) {
@@ -1665,7 +1687,7 @@ function payloadFileSync(pointer) {
       let reject;
       const p = new Promise((res, rej) => {
         resolve = res;
-        reject  = rej;
+        reject = rej;
       });
 
       p.child = o.apply(

--- a/prelude/common.js
+++ b/prelude/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var fs = require('fs');
 var path = require('path');
 
 exports.STORE_BLOB = 0;
@@ -153,7 +154,6 @@ exports.substituteDenominator = function substituteDenominator(f, denominator) {
 };
 
 exports.snapshotify = function snapshotify(file, slash) {
-  assert.strictEqual(file, normalizePath(file));
   return injectSnapshot(replaceSlashes(file, slash));
 };
 
@@ -170,8 +170,9 @@ if (win32) {
       slice112 === ':/snapshot/' ||
       slice112 === ':\\snapshot' ||
       slice112 === ':/snapshot'
-    )
+    ) {
       return true;
+    }
     return false;
   };
 } else {
@@ -229,3 +230,12 @@ if (win32) {
     return f;
   };
 }
+
+function toNormalizedRealPath(requestPath) {
+  const file = normalizePath(requestPath);
+  if (fs.existsSync(file)) {
+    return fs.realpathSync(file);
+  }
+  return file;
+}
+exports.toNormalizedRealPath = toNormalizedRealPath;

--- a/prelude/diagnostic.js
+++ b/prelude/diagnostic.js
@@ -1,0 +1,77 @@
+/* eslint-disable global-require */
+/* eslint-disable no-console */
+
+'use strict';
+
+(function installDiagnostic() {
+  const fs = require('fs');
+  const path = require('path');
+
+  const win32 = process.platform === 'win32';
+
+  function dumpLevel(folderPath, level) {
+    let totalSize = 0;
+    const d = fs.readdirSync(folderPath);
+    for (let j = 0; j < d.length; j += 1) {
+      const f = path.join(folderPath, d[j]);
+      //  const isSymbolicLink = fs.statSync(f).isSymbolicLink();
+      const realPath = fs.realpathSync(f);
+      const isSymbolicLink2 = f !== realPath;
+
+      const s = fs.statSync(f);
+      totalSize += s.size;
+      console.log(
+        ' '.padStart(level * 2, ' '),
+        d[j],
+        s.size,
+        isSymbolicLink2 ? `=> ${realPath}` : ' '
+      );
+
+      if (s.isDirectory() && !isSymbolicLink2) {
+        totalSize += dumpLevel(f, level + 1);
+      }
+    }
+    return totalSize;
+  }
+  function wrap(obj, name) {
+    const f = fs[name];
+    obj[name] = (...args) => {
+      const args1 = Object.values(args);
+      console.log(
+        `fs.${name}`,
+        args1.filter((x) => typeof x === 'string')
+      );
+      return f.apply(this, args1);
+    };
+  }
+  if (process.env.DEBUG_PKG) {
+    console.log('------------------------------- virtual file system');
+    const startFolder = win32 ? 'C:\\snapshot' : '/snapshot';
+    const totalSize = dumpLevel(startFolder, 2);
+    console.log('Total size = ', totalSize);
+    wrap(fs, 'openSync');
+    wrap(fs, 'open');
+    wrap(fs, 'readSync');
+    wrap(fs, 'read');
+    wrap(fs, 'writeSync');
+    wrap(fs, 'write');
+    wrap(fs, 'closeSync');
+    wrap(fs, 'readFileSync');
+    wrap(fs, 'close');
+    wrap(fs, 'readFile');
+    wrap(fs, 'readdirSync');
+    wrap(fs, 'readdir');
+    wrap(fs, 'realpathSync');
+    wrap(fs, 'realpath');
+    wrap(fs, 'statSync');
+    wrap(fs, 'stat');
+    wrap(fs, 'lstatSync');
+    wrap(fs, 'lstat');
+    wrap(fs, 'fstatSync');
+    wrap(fs, 'fstat');
+    wrap(fs, 'existsSync');
+    wrap(fs, 'exists');
+    wrap(fs, 'accessSync');
+    wrap(fs, 'access');
+  }
+})();

--- a/test/test-10-pnpm/.gitignore
+++ b/test/test-10-pnpm/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+pnpm-lock.yaml
+test-*

--- a/test/test-10-pnpm/main.js
+++ b/test/test-10-pnpm/main.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const utils = require('../utils.js');
+
+assert(__dirname === process.cwd());
+
+const target = process.argv[2] || 'host';
+const input = './test.js';
+const output = './test-output.exe';
+
+console.log('target = ', target);
+
+// remove any possible left-over
+utils.vacuum.sync('./node_modules');
+utils.vacuum.sync('./pnpm-lock.yaml');
+
+// launch `pnpm install`
+const pnpmlog = utils.spawn.sync(
+  path.join(
+    path.dirname(process.argv[0]),
+    'npx' + (process.platform === 'win32' ? '.cmd' : '')
+  ),
+  ['pnpm', 'install'],
+  { cwd: path.dirname(output), expect: 0 }
+);
+console.log('pnpm log :', pnpmlog);
+
+// verify that we have the .pnpm folder and a symlinks module in node_modules
+assert(fs.lstatSync(path.join(__dirname, 'node_modules/.pnpm')).isDirectory());
+assert(
+  fs
+    .lstatSync(path.join(__dirname, 'node_modules/better-assert'))
+    .isSymbolicLink()
+);
+
+const logPkg = utils.pkg.sync([
+  '--target',
+  target,
+  '--debug',
+  '--output',
+  output,
+  input,
+]);
+assert(logPkg.match(/adding symlink/g));
+
+// check that produced executable is running and produce the expected output.
+const log = utils.spawn.sync(output, [], {
+  cwd: path.dirname(output),
+  expect: 0,
+});
+assert(log === '42\n');
+
+// clean up
+utils.vacuum.sync(output);
+utils.vacuum.sync('./node_modules');
+utils.vacuum.sync('./pnpm-lock.yaml');
+
+console.log('OK');

--- a/test/test-10-pnpm/package.json
+++ b/test/test-10-pnpm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-pnpm",
+  "version": "1.0.0",
+  "description": "",
+  "main": "test.js",
+  "scripts": {
+    "preinstall": "npx only-allow pnpm",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "better-assert": "^1.0.2"
+  }
+}

--- a/test/test-10-pnpm/test.js
+++ b/test/test-10-pnpm/test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const assert = require('better-assert');
+assert(21 * 2 === 42);
+console.log(42);

--- a/test/test-11-pnpm/.gitignore
+++ b/test/test-11-pnpm/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+pnpm-lock.yaml
+test-*

--- a/test/test-11-pnpm/main.js
+++ b/test/test-11-pnpm/main.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const utils = require('../utils.js');
+
+console.log(__dirname, process.cwd());
+assert(__dirname === process.cwd());
+
+const target = process.argv[2] || 'host';
+const input = './test.js';
+const output = './test-output.exe';
+
+console.log('target = ', target);
+
+// remove any possible left-over
+utils.vacuum.sync('./node_modules');
+utils.vacuum.sync('./pnpm-lock.yaml');
+
+// launch `pnpm install`
+const pnpmlog = utils.spawn.sync(
+  path.join(
+    path.dirname(process.argv[0]),
+    'npx' + (process.platform === 'win32' ? '.cmd' : '')
+  ),
+  ['pnpm', 'install'],
+  { cwd: path.dirname(output), expect: 0 }
+);
+console.log('pnpm log :', pnpmlog);
+
+// verify that we have the .pnpm folder and a symlinks module in node_modules
+assert(fs.lstatSync(path.join(__dirname, 'node_modules/.pnpm')).isDirectory());
+assert(
+  fs.lstatSync(path.join(__dirname, 'node_modules/bonjour')).isSymbolicLink()
+);
+
+const logPkg = utils.pkg.sync([
+  '--target',
+  target,
+  '--debug',
+  '--output',
+  output,
+  input,
+]);
+assert(logPkg.match(/adding symlink/g));
+
+// check that produced executable is running and produce the expected output.
+const log = utils.spawn.sync(output, [], {
+  cwd: path.dirname(output),
+  expect: 0,
+});
+assert(log === '42\n');
+
+// clean up
+utils.vacuum.sync(output);
+utils.vacuum.sync('./node_modules');
+utils.vacuum.sync('./pnpm-lock.yaml');
+
+console.log('OK');

--- a/test/test-11-pnpm/package.json
+++ b/test/test-11-pnpm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-pnpm",
+  "version": "1.0.0",
+  "description": "",
+  "main": "test.js",
+  "scripts": {
+    "preinstall": "npx only-allow pnpm",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bonjour": "*"
+  }
+}

--- a/test/test-11-pnpm/test.js
+++ b/test/test-11-pnpm/test.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('bonjour');
+console.log(42);

--- a/test/test-50-many-arrow-functions/test-z-creator.js
+++ b/test/test-50-many-arrow-functions/test-z-creator.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable no-useless-concat
 let s =
   'function EventEmitter () {\n' +
   '  this.listeners = [];\n' +
@@ -15,11 +16,11 @@ let s =
   'const ee = new EventEmitter();\n';
 
 for (let i = 0; i < 140; i += 1) {
-  s += "ee.on('message', (data) => {\n" + '  console.log(data);\n' + '});\n';
+  s += "ee.on('message', (data) => {\n  console.log(data);\n});\n";
 }
 
 s += "ee.emit('message', 'hooray');\n";
 
-s = "'use strict';\n" + '\n' + s;
+s = "'use strict';\n\n" + s;
 
 require('fs').writeFileSync('test-x-index.js', s);

--- a/test/test-50-many-callbacks/test-z-creator.js
+++ b/test/test-50-many-callbacks/test-z-creator.js
@@ -1,11 +1,13 @@
 'use strict';
 
+// eslint-disable no-useless-concat
+
 let s = "console.log('test');\n";
 
 for (let i = 0; i < 100; i += 1) {
   s = 'setTimeout(function () {\n' + s + '}, 0);\n';
 }
 
-s = "'use strict';\n" + '\n' + s;
+s = "'use strict';\n\n" + s;
 
 require('fs').writeFileSync('test-x-index.js', s);

--- a/test/test-79-npm/cron/cron.js
+++ b/test/test-79-npm/cron/cron.js
@@ -4,10 +4,9 @@ var CronJob = require('cron').CronJob;
 
 var counter = 0;
 
-new CronJob(
+new CronJob( // eslint-disable-line no-new
   '* * * * * *',
   function () {
-    // eslint-disable-line no-new
     counter += 1;
   },
   null,

--- a/test/test-79-npm/ejs/ejs.js
+++ b/test/test-79-npm/ejs/ejs.js
@@ -2,7 +2,7 @@
 
 var ejs = require('ejs');
 
-var s = '<% if (user) { %>' + '<h2><%= user.name %></h2>' + '<% } %>';
+var s = '<% if (user) { %><h2><%= user.name %></h2><% } %>';
 
 var template = ejs.compile(s, { client: true });
 var out = template({ user: { name: 'klopov' } });

--- a/test/test.js
+++ b/test/test.js
@@ -25,7 +25,8 @@ if (process.env.CI) {
     target === 'node7' ||
     target === 'node9' ||
     target === 'node11' ||
-    target === 'node13'
+    target === 'node13' ||
+    target === 'node15'
   ) {
     console.log(target + ' is skipped in CI!');
     console.log('');


### PR DESCRIPTION
Add a mechanism to follow and track symlinks, making `pkg` work with PNPM and also package installed with `npm link` inside your `node_modules` folder.

Closes https://github.com/vercel/pkg/issues/941.