### PR TITLE
Support mkdir at mountpoints

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -1247,7 +1247,7 @@ function payloadFileSync(pointer) {
   // mkdir /////////////////////////////////////////////////////////
   // ///////////////////////////////////////////////////////////////
 
-  function mkdirInSnapshot(path_, cb) {
+  function mkdirFailInSnapshot(path_, cb) {
     var cb2 = cb || rethrow;
     return cb2(
       new Error('Cannot mkdir in a snapshot. Try mountpoints instead.')
@@ -1262,7 +1262,7 @@ function payloadFileSync(pointer) {
       return ancestor.mkdirSync.apply(fs, translateNth(arguments, 0, path));
     }
 
-    return mkdirInSnapshot(path);
+    return mkdirFailInSnapshot(path);
   };
 
   fs.mkdir = function mkdir(path) {
@@ -1274,7 +1274,7 @@ function payloadFileSync(pointer) {
     }
 
     var callback = dezalgo(maybeCallback(arguments));
-    mkdirInSnapshot(path, callback);
+    mkdirFailInSnapshot(path, callback);
   };
 
   // ///////////////////////////////////////////////////////////////

--- a/test/test-1120-mkdir-mountpoints/main.js
+++ b/test/test-1120-mkdir-mountpoints/main.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const assert = require('assert');
+const utils = require('../utils.js');
+
+assert(!module.parent);
+assert(__dirname === process.cwd());
+
+const target = process.argv[2] || 'host';
+const input = './test-x-index.js';
+const output = './run-time/test-output.exe';
+
+let right;
+utils.mkdirp.sync(path.dirname(output));
+
+utils.pkg.sync(['--target', target, '--output', output, input]);
+
+right = utils.spawn.sync('./' + path.basename(output), [], {
+  cwd: path.dirname(output),
+});
+
+assert.strictEqual(right, 'hello.txt\n');
+
+utils.vacuum.sync(path.dirname(output));

--- a/test/test-1120-mkdir-mountpoints/test-x-index.js
+++ b/test/test-1120-mkdir-mountpoints/test-x-index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var myDirectory = path.dirname(process.execPath);
+
+process.pkg.mount(
+  path.join(__dirname, 'plugins-D-ext'),
+  path.join(myDirectory, 'plugins-D-ext')
+);
+
+fs.mkdirSync('./plugins-D-ext/');
+fs.writeFileSync('./plugins-D-ext/hello.txt', 'hello world!');
+
+console.log(
+  fs.readdirSync(path.join(__dirname, './plugins-D-ext/')).join('\n')
+);


### PR DESCRIPTION
I'm working on a CLI tool that bundles some code, but then mirrors the directory structure out to the filesystem. This is done using mountpoints and this patch that allows `fs.mkdir` to apply to them.