### PR TITLE
Fix isPublic check for licenses array

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ into executable), it may be useful to look through the log.
 By default, your source code is precompiled to v8 bytecode before being written
 to the output file. To disable this feature, pass `--no-bytecode` to `pkg`.
 
-> Why would you want to do this?
+#### Why would you want to do this?
 
 If you need a reproducible build
 process where your executable hashes (e.g. md5, sha1, sha256, etc.) are the
@@ -157,7 +157,7 @@ same value between builds. Because compiling bytecode is not deterministic
 results in executables with differing hashed values. Disabling bytecode
 compilation allows a given input to always have the same output.
 
-> Why would you NOT want to do this?
+#### Why would you NOT want to do this?
 
 While compiling to bytecode does not make your source code 100% secure, it does
 add a small layer of security/privacy/obscurity to your source code. Turning
@@ -165,6 +165,17 @@ off bytecode compilation causes the raw source code to be written directly to
 the executable file. If you're on \*nix machine and would like an example, run
 `pkg` with the `--no-bytecode` flag, and use the GNU strings tool on the
 output. You then should be able to grep your source code.
+
+#### Other considerations
+
+Specifying `--no-bytecode` will fail if there are any packages in your project that aren't explicitly marked
+as public by the `license` in their `package.json`.
+By default, `pkg` will check the license of each package and make sure that stuff that isn't meant for the public will
+only be included as bytecode.
+
+If you do require building pkg binaries for other architectures and/or depend on a package with a broken
+`license` in its `package.json`, you can override this behaviour by either explicitly whitelisting packages to be public
+using `--public-packages "packageA,packageB"` or setting all packages to public using `--public-packages "*"`
 
 ### Build
 

--- a/lib/help.ts
+++ b/lib/help.ts
@@ -7,16 +7,18 @@ export default function help() {
 
   ${chalk.dim('Options:')}
 
-    -h, --help       output usage information
-    -v, --version    output pkg version
-    -t, --targets    comma-separated list of targets (see examples)
-    -c, --config     package.json or any json file with top-level config
-    --options        bake v8 options into executable to run with them on
-    -o, --output     output file name or template for several files
-    --out-path       path to save output one or more executables
-    -d, --debug      show more information during packaging process [off]
-    -b, --build      don't download prebuilt base binaries, build them
-    --public         speed up and disclose the sources of top-level project
+    -h, --help           output usage information
+    -v, --version        output pkg version
+    -t, --targets        comma-separated list of targets (see examples)
+    -c, --config         package.json or any json file with top-level config
+    --options            bake v8 options into executable to run with them on
+    -o, --output         output file name or template for several files
+    --out-path           path to save output one or more executables
+    -d, --debug          show more information during packaging process [off]
+    -b, --build          don't download prebuilt base binaries, build them
+    --public             speed up and disclose the sources of top-level project
+    --public-packages    force specified packages to be considered public
+    --no-bytecode        skip bytecode generation and include source files as plain js
 
   ${chalk.dim('Examples:')}
 
@@ -28,7 +30,11 @@ export default function help() {
     ${chalk.cyan('$ pkg -t node14-win-arm64 index.js')}
   ${chalk.gray('–')} Makes executables for target machines of your choice
     ${chalk.cyan('$ pkg -t node12-linux,node14-linux,node14-win index.js')}
-  ${chalk.gray('–')} Bakes '--expose-gc' into executable
-    ${chalk.cyan('$ pkg --options expose-gc index.js')}
+  ${chalk.gray('–')} Bakes '--expose-gc' and '--max-heap-size=34' into executable
+    ${chalk.cyan('$ pkg --options "expose-gc,max-heap-size=34" index.js')}
+  ${chalk.gray('–')} Consider packageA and packageB to be public
+    ${chalk.cyan('$ pkg --public-packages "packageA,packageB" index.js')}
+  ${chalk.gray('–')} Consider all packages to be public
+    ${chalk.cyan('$ pkg --public-packages "*" index.js')}
 `);
 }

--- a/lib/walker.ts
+++ b/lib/walker.ts
@@ -87,7 +87,7 @@ function isPublic(config: PackageJson) {
     license = licenses;
   }
 
-  if (license) {
+  if (license && !Array.isArray(license)) {
     license = typeof license === 'string' ? license : license.type;
   }
 


### PR DESCRIPTION
As it turns out, not including bytecode is broken for modules that have a licenses array in their package.json.

One example of this is `utils-merge` which is a dependency of `express`.

Without this check, `license` will become undefined since there's no `type` property on that array.
This causes the module to be listed as non-public which means that it doesn't get included as CONTENT
That in turn triggers the exception when building without bytecode.

Anyways, this was not fun to debug, because there's no mention anywhere of this isPublic check.