### PR TITLE
Use "linuxstatic" to generate bytecode for different arch on Linux

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -154,9 +154,23 @@ function stringifyTargetForOutput(
   return a.join('-');
 }
 
-function fabricatorForTarget(target: NodeTarget) {
-  const { nodeRange, arch } = target;
-  return { nodeRange, platform: hostPlatform, arch };
+function fabricatorForTarget({ nodeRange, arch }: NodeTarget) {
+  let fabPlatform = hostPlatform;
+
+  if (
+    hostArch !== arch &&
+    (hostPlatform === 'linux' || hostPlatform === 'alpine')
+  ) {
+    // With linuxstatic, it is possible to generate bytecode for different
+    // arch with simple QEMU configuration instead of the entire sysroot.
+    fabPlatform = 'linuxstatic';
+  }
+
+  return {
+    nodeRange,
+    platform: fabPlatform,
+    arch,
+  };
 }
 
 const dryRunResults: Record<string, boolean> = {};


### PR DESCRIPTION
Currently `pkg` can't generate executable for different arch:

> Warning Failed to make bytecode node14-arm64 for file ...

as it attempts to run Node of different arch to make bytecode.

We can set up QEMU and binfmt to allow emulation. However, the "linux"
binary needs libraries from the system, and it is PITA to set up the
entire sysroot of a different arch.

This change workarounds the issue by using "linuxstatic" to generate
bytecode for different arch.