### PR TITLE
support execArgv when forking with child_process

### DIFF
--- a/test/test-1157-fork-exec-argv/main.js
+++ b/test/test-1157-fork-exec-argv/main.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const utils = require('../utils.js');
+
+assert(!module.parent);
+assert(__dirname === process.cwd());
+
+const target = process.argv[2] || 'host';
+const input = './test-x-index.js';
+const output = './test-output.exe';
+
+process.env.NODE_OPTIONS = '--max-old-space-size=777';
+
+utils.pkg.sync(['--bytecode', '--target', target, '--output', output, input]);
+
+utils.spawn.sync(output, [], { expect: 4 });
+
+utils.vacuum.sync(output);
+
+utils.pkg.sync([
+  '--public',
+  '--public-packages=*',
+  '--no-bytecode',
+  '--target',
+  target,
+  '--output',
+  output,
+  input,
+]);
+
+utils.spawn.sync(output, []);
+
+utils.vacuum.sync(output);

--- a/test/test-1157-fork-exec-argv/test-x-index.js
+++ b/test/test-1157-fork-exec-argv/test-x-index.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const title = 'some-custom-title';
+const assert = require('assert');
+
+if (process.argv.indexOf('child') !== -1) {
+  child();
+} else {
+  parent();
+}
+
+function parent() {
+  const cp = require('child_process');
+  cp.fork(__filename, ['child'], {
+    execArgv: ['--title', title],
+  }).on('exit', (code) => {
+    process.exit(typeof code === 'number' ? code : 1);
+  });
+  setTimeout(process.exit, 5000, 1);
+}
+
+function child() {
+  assert(
+    process.env.NODE_OPTIONS.includes('--max-old-space-size=777'),
+    'main.js should have set NODE_OPTIONS=--max-old-space-size=777 and it should trickle down here.\n' +
+      `process.env.NODE_OPTIONS: ${JSON.stringify(process.env.NODE_OPTIONS)}`
+  );
+  assert(
+    process.title === title,
+    `process.title should be set by the parent through execArgv when forking (got ${process.title})`
+  );
+}


### PR DESCRIPTION
Implement a workaround to convert opts.execArgv into
opts.env.NODE_OPTIONS when calling child_process.fork.

Note that this will most likely require you to package apps using
--no-bytecode because some node options will prevent you from running
the packaged bytecode with new options.

Fixes https://github.com/vercel/pkg/issues/334
Fixes https://github.com/vercel/pkg/issues/909