### PR TITLE
Bump to vercel/pkg-fetch@v3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "into-stream": "^6.0.0",
     "minimist": "^1.2.5",
     "multistream": "^4.1.0",
-    "pkg-fetch": "3.1.1",
+    "pkg-fetch": "3.2.1",
     "prebuild-install": "6.0.1",
     "progress": "^2.0.3",
     "resolve": "^1.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,10 +2127,10 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-fetch@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.1.1.tgz"
-  integrity sha512-3GfpNwbwoTxge2TrVp6Oyz/FZJOoxF1r0+1YikOhnBXa2Di/VOJKtUObFHap76BFnyFo1fwh5vARWFR9TzLKUg==
+pkg-fetch@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.2.1.tgz#af71b20572b8b8b3ad0ee8389d6604dfbdf43770"
+  integrity sha512-yFbrxI1a+gSYcwnUCXKp0bFjwiMLoOHEI24fOEZwZiq1oja3fun7pP0/aMFa/72yiNbbva5jaiIxnh6O9ZOceg==
   dependencies:
     chalk "^4.1.0"
     fs-extra "^9.1.0"


### PR DESCRIPTION
### Changes

- Use Docker to build binaries for linux-arm64 (vercel/pkg-fetch#191)
- Enable LTO for macOS binaries (vercel/pkg-fetch#192)
- Bump to Node v16.3.0 (vercel/pkg-fetch#196)
- Add support for linuxstatic-armv7 platform* (vercel/pkg-fetch#194, @Hypfer)

\* best-effort basis, not semver-protected.