### PR TITLE
Add docs for automatic releases w. GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,65 @@ await exec(['app.js', '--target', 'host', '--output', 'app.exe']);
 // do something with app.exe, run, test, upload, deploy, etc
 ```
 
+## Automate Releases with GitHub Actions
+
+[GitHub Actions](https://docs.github.com/en/actions) can be used to automatically run `pkg` when a specific event has occurred.
+
+For example, to automatically run `pkg` to create executables and upload them as assets to a new release on GitHub every time a new Git tag is pushed, try setting up [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release) as follows:
+
+1. Add a new file in your project called `.github/workflows/release.yml` (create the directories `.github/workflow` in case they don't exist in your project) and add this file content:
+
+```yaml
+name: Build and release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: yarn --frozen-lockfile
+      - run: npm install --global pkg
+      - name: Build
+        run: pkg index.js --output your-program-name-here --targets linux,macos,win
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            your-program-name-here-linux
+            your-program-name-here-macos
+            your-program-name-here-win.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+2. Create a new Git tag with the version that you want:
+
+```bash
+git tag -a v1.0.0
+```
+
+3. Push the new tag to GitHub:
+
+```bash
+git push --tags
+```
+
+This will create a new release under Releases on your GitHub repo that will contain the built executables as assets:
+
+![Releases page on GitHub repo showing release with assets](https://user-images.githubusercontent.com/1935696/124388004-fe2bcb00-dce0-11eb-9701-78f06b31b23f.png)
+
+Every time that you want to create a new release with assets, create a new tag and push it (steps 2 and 3 above).
+
 ## Troubleshooting
 
 ### Error: ENOENT: no such file or directory, uv_chdir


### PR DESCRIPTION
Hi there, thanks for `pkg`, really amazing!

Wanted to test the waters on documenting usage of GitHub actions to automate building using `pkg` and uploading the executables as assets to a GitHub release.

Example here:

- Workflow: https://github.com/jonaschlegel/lgo-agisoft-converter/blob/main/.github/workflows/release.yml
- Release: https://github.com/jonaschlegel/lgo-agisoft-converter/releases/tag/v1.0.0