### PR TITLE
Allow to fallback to "ldid" for macOS ad-hoc signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ note that by default `pkg` has to run the executable of the
 
 `macos-arm64` is experimental. Be careful about the [mandatory code signing requirement](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes).
 The final executable has to be signed (ad-hoc signature is sufficient) with `codesign`
-utility of macOS, or the end-user has no way to permit it to run at all. `pkg` ad-hoc
-signs the final executable if you run `pkg` on macOS. Preferably, you should replace
-this signature with your own trusted Apple Developer ID.
+utility of macOS (or `ldid` utility on Linux). Otherwise, the executable will be killed
+by kernel and the end-user has no way to permit it to run at all. `pkg` tries to ad-hoc
+sign the final executable. If necessary, you can replace this signature with your own
+trusted Apple Developer ID.
+
+To be able to generate executables for all supported architectures and platforms, run
+`pkg` on a Linux host with binfmt (`QEMU` emulation) configured and `ldid` installed.
 
 ### Config
 

--- a/lib/mach-o.ts
+++ b/lib/mach-o.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from 'child_process';
+
 function parseCStr(buf: Buffer) {
   for (let i = 0; i < buf.length; i += 1) {
     if (buf[i] === 0) {
@@ -55,4 +57,12 @@ function patchMachOExecutable(file: Buffer) {
   return file;
 }
 
-export { patchMachOExecutable };
+function signMachOExecutable(executable: string) {
+  try {
+    execFileSync('codesign', ['--sign', '-', executable], { stdio: 'inherit' });
+  } catch {
+    execFileSync('ldid', ['-S', executable], { stdio: 'inherit' });
+  }
+}
+
+export { patchMachOExecutable, signMachOExecutable };


### PR DESCRIPTION
ldid is a "codesign"-like open source utility to sign Darwin (macOS/iOS) executable or package.

It is possible to run ldid on Linux.

Bug: #1251