### PR TITLE
Fix warnings when packaging with leveldown.

### DIFF
--- a/dictionary/leveldown.js
+++ b/dictionary/leveldown.js
@@ -1,10 +1,3 @@
 'use strict';
 
-module.exports = {
-  pkg: {
-    patches: {
-      'binding.js': ['__dirname', "require('path').dirname(process.execPath)"],
-    },
-    deployFiles: [['prebuilds', 'prebuilds', 'directory']],
-  },
-};
+module.exports = {};


### PR DESCRIPTION
Fixes #1264.
Relates to #837

The goal of this PR is to remove warnings when packaging a project that includes the leveldown native module.
This change should;
* Remove warnings when packaging leveldown.
* packaged executable should run without needing to include the leveldown prebuilds directory with the executable.
