### PR TITLE
Update to support latest LTS node version(#1235)

### DIFF
--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -3,14 +3,14 @@
   "license": "ISC",
   "bin": "index.js",
   "dependencies": {
-    "express": "4.15.2"
+    "express": "^4.17.1"
   },
   "pkg": {
     "assets": [
       "views/**/*"
     ],
     "targets": [
-      "node8"
+      "node16"
     ]
   }
 }


### PR DESCRIPTION
This pull request solve #1235 error on pkg main example program.

This error occur because nodejs 8 has reached end-of-life end on the 31st 12/2019 is not recommended to be used in production anymore.

```
const { isRegExp1 } = require('util').types; console.log(typeof isRegExp1);
        ^

TypeError: Cannot destructure property `isRegExp1` of 'undefined' or 'null'.
    at [eval]:1:38
    at ContextifyScript.Script.runInThisContext (vm.js:50:33)
    at Object.runInThisContext (vm.js:139:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:653:30)
    at evalScript (bootstrap_node.js:479:27)
    at startup (bootstrap_node.js:180:9)
    at bootstrap_node.js:625:3
```