### PR TITLE
fix: better support of `.node` files

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -159,7 +159,7 @@ function createMountpoint(interior, exterior) {
 }
 
 function copyFileSync(source, target) {
-  var targetFile = target;
+  let targetFile = target;
 
   // If target is a directory, a new file with the same name will be created
   if (fs.existsSync(target)) {
@@ -172,10 +172,10 @@ function copyFileSync(source, target) {
 }
 
 function copyFolderRecursiveSync(source, target) {
-  var files = [];
+  let files = [];
 
   // Check if folder needs to be created or integrated
-  var targetFolder = path.join(target, path.basename(source));
+  const targetFolder = path.join(target, path.basename(source));
   if (!fs.existsSync(targetFolder)) {
     fs.mkdirSync(targetFolder);
   }
@@ -184,13 +184,20 @@ function copyFolderRecursiveSync(source, target) {
   if (fs.lstatSync(source).isDirectory()) {
     files = fs.readdirSync(source);
     files.forEach((file) => {
-      var curSource = path.join(source, file);
+      const curSource = path.join(source, file);
       if (fs.lstatSync(curSource).isDirectory()) {
         copyFolderRecursiveSync(curSource, targetFolder);
       } else {
         copyFileSync(curSource, targetFolder);
       }
     });
+  }
+}
+
+function createDirRecursively(dir) {
+  if (!fs.existsSync(dir)) {
+    createDirRecursively(path.join(dir, '..'));
+    fs.mkdirSync(dir);
   }
 }
 
@@ -2077,13 +2084,13 @@ function payloadFileSync(pointer) {
       // the hash is needed to be sure we reload the module in case it changes
       const hash = createHash('sha256').update(moduleContent).digest('hex');
 
-      // Example: /tmp/<hash>
+      // Example: /tmp/pkg/<hash>
       const tmpFolder = path.join(tmpdir(), 'pkg', hash);
       if (!fs.existsSync(tmpFolder)) {
         // here we copy all files from the snapshot module folder to temporary folder
         // we keep the module folder structure to prevent issues with modules that are statically
         // linked using relative paths (Fix #1075)
-        fs.mkdirSync(tmpFolder, { recursive: true });
+        createDirRecursively(tmpFolder);
         copyFolderRecursiveSync(modulePkgFolder, tmpFolder);
       }
 

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -183,7 +183,7 @@ function copyFolderRecursiveSync(source, target) {
   // Copy
   if (fs.lstatSync(source).isDirectory()) {
     files = fs.readdirSync(source);
-    files.forEach(function (file) {
+    files.forEach((file) => {
       var curSource = path.join(source, file);
       if (fs.lstatSync(curSource).isDirectory()) {
         copyFolderRecursiveSync(curSource, targetFolder);
@@ -2056,7 +2056,6 @@ function payloadFileSync(pointer) {
     const modulePath = revertMakingLong(args[1]);
     const moduleBaseName = path.basename(modulePath);
     const moduleFolder = path.dirname(modulePath);
-    const unknownModuleErrorRegex = /([^:]+): cannot open shared object file: No such file or directory/;
 
     // Example: moduleFolder = /snapshot/appname/node_modules/sharp/build/Release
     const modulePkgPathRegex = /.*?node_modules\/((.+?)\/.*)/;

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2078,7 +2078,7 @@ function payloadFileSync(pointer) {
       const hash = createHash('sha256').update(moduleContent).digest('hex');
 
       // Example: /tmp/<hash>
-      const tmpFolder = path.join(tmpdir(), hash);
+      const tmpFolder = path.join(tmpdir(), 'pkg', hash);
       if (!fs.existsSync(tmpFolder)) {
         // here we copy all files from the snapshot module folder to temporary folder
         // we keep the module folder structure to prevent issues with modules that are statically


### PR DESCRIPTION
When a `.node` file is required `pkg` copies it in a temporary folder like `/tmp/<hash>/addon.node` the problem is that for modules like `sharp` this isn't working as them are statically linked to other `.so` files using relative paths. This pr will copy the entire module folder inside the temporary directory, this allows also to remove the `tryImport` function as there is no reason to try again if that fails. 

I tested this on my end and it's working

I also grouped all hash folders inside `pkg` folder to be sure that the copy will run when users will update pkg, otherwise the copy may not be done when the folder already exists but was created with a previous pkg version

cc @jesec @leerob @erossignon 

Fixes #1075