### PR TITLE
bootstrap: skip regex when dlopen path isn't inside snapshot

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2064,19 +2064,19 @@ function payloadFileSync(pointer) {
     const moduleBaseName = path.basename(modulePath);
     const moduleFolder = path.dirname(modulePath);
 
-    // Example: moduleFolder = /snapshot/appname/node_modules/sharp/build/Release
-    const modulePkgPathRegex = /.*?node_modules\/((.+?)\/.*)/;
-    // Example: modulePackagePath = sharp/build/Release
-    const modulePackagePath = moduleFolder.match(modulePkgPathRegex)[1];
-    // Example: modulePackageName =  sharp
-    const modulePackageName = moduleFolder.match(modulePkgPathRegex)[2];
-    // Example: modulePkgFolder = /snapshot/appname/node_modules/sharp
-    const modulePkgFolder = moduleFolder.replace(
-      modulePackagePath,
-      modulePackageName
-    );
-
     if (insideSnapshot(modulePath)) {
+      // Example: moduleFolder = /snapshot/appname/node_modules/sharp/build/Release
+      const modulePkgPathRegex = /.*?node_modules\/((.+?)\/.*)/;
+      // Example: modulePackagePath = sharp/build/Release
+      const modulePackagePath = moduleFolder.match(modulePkgPathRegex)[1];
+      // Example: modulePackageName =  sharp
+      const modulePackageName = moduleFolder.match(modulePkgPathRegex)[2];
+      // Example: modulePkgFolder = /snapshot/appname/node_modules/sharp
+      const modulePkgFolder = moduleFolder.replace(
+        modulePackagePath,
+        modulePackageName
+      );
+
       const moduleContent = fs.readFileSync(modulePath);
 
       // Node addon files and .so cannot be read with fs directly, they are loaded with process.dlopen which needs a filesystem path


### PR DESCRIPTION
When tring to import a file with `dlopen` and it's not inside snapshot regex could fail and throw error

Fixes #1319