### PR TITLE
Add support for `node:` protocol

### DIFF
--- a/lib/walker.ts
+++ b/lib/walker.ts
@@ -846,7 +846,10 @@ class Walker {
   ) {
     for (const derivative of derivatives) {
       if (natives[derivative.alias]) continue;
-
+      if (derivative.alias.startsWith('node:')) {
+        if (natives[derivative.alias.substr(5)]) continue;
+      }
+      
       switch (derivative.aliasType) {
         case ALIAS_AS_RELATIVE:
           await this.stepDerivatives_ALIAS_AS_RELATIVE(


### PR DESCRIPTION
This PR adds support for pkg to identify any built-in/core module that's being imported using the `node:` protocol.

This would fix fix #1309.
This would also fix #1363.
