### PR TITLE
fix: pick up the correct file argument when forking a process

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -74,7 +74,12 @@ if (NODE_VERSION_MAJOR < 12 || require('worker_threads').isMainThread) {
   }
 }
 
-if (process.env.PKG_EXECPATH === EXECPATH) {
+if (process.send) {
+  // if process.send is set, it means the process was forked,
+  // and the runtime file is the third argument
+  process.argv[1] = process.argv[2];
+  process.argv.splice(2, 1);
+} else if (process.env.PKG_EXECPATH === EXECPATH) {
   process.argv.splice(1, 1);
 
   if (process.argv[1] && process.argv[1] !== '-') {

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -101,12 +101,14 @@ if (process.send) {
 
 [, ENTRYPOINT] = process.argv;
 
-const index = process.argv.findIndex((x) => x === 'PKG_DUMMY_ENTRYPOINT');
-if (index !== -1) {
+const dummyPointIndex = process.argv.findIndex(
+  (x) => x === 'PKG_DUMMY_ENTRYPOINT'
+);
+if (dummyPointIndex !== -1) {
   // TODO: document/refactor this
-  process.argv.splice(index, 1);
-  process.argv[index] = path.resolve(process.argv[index]);
-  ENTRYPOINT = process.argv[index];
+  process.argv.splice(dummyPointIndex, 1);
+  process.argv[dummyPointIndex] = path.resolve(process.argv[dummyPointIndex]);
+  ENTRYPOINT = process.argv[dummyPointIndex];
 }
 
 delete process.env.PKG_EXECPATH;


### PR DESCRIPTION
This enables you to fork a process with run time arguments, for instance
--max_old_space_size=1024.

This is an old fix by @bergheim. Never submitted a PR for it

Fixes #459 
Fixes #1461 