### PR TITLE
fix infinite loop issue #1469

### DIFF
--- a/lib/walker.ts
+++ b/lib/walker.ts
@@ -303,7 +303,7 @@ function stepDetect(
 
 function findCommonJunctionPoint(file: string, realFile: string) {
   // find common denominator => where the link changes
-  while (toNormalizedRealPath(path.dirname(file)) === path.dirname(realFile)) {
+  while (path.basename(file) === path.basename(realFile)) {
     file = path.dirname(file);
     realFile = path.dirname(realFile);
   }


### PR DESCRIPTION
issues:
https://github.com/vercel/pkg/issues/1469
when the scope is as follows, there will be an infinite loop.
{
"file": "D:\project-name\node_modules\element-ui\package.json",
"realFile": "D:\project-name\node_modules\_element- ui@2.15.5 @element-ui\package. json"
}
The final scope is:
{
"file": "D:\",
"realFile": "D:\"
}