### PR TITLE
Copy module folders always to temporary folder

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2091,13 +2091,11 @@ function payloadFileSync(pointer) {
         // Example: modulePkgFolder = /snapshot/appname/node_modules/sharp
         const modulePkgFolder = parts.slice(0, mIndex + 1).join(path.sep);
 
-        if (!fs.existsSync(tmpFolder)) {
-          // here we copy all files from the snapshot module folder to temporary folder
-          // we keep the module folder structure to prevent issues with modules that are statically
-          // linked using relative paths (Fix #1075)
-          createDirRecursively(tmpFolder);
-          copyFolderRecursiveSync(modulePkgFolder, tmpFolder);
-        }
+        // here we copy all files from the snapshot module folder to temporary folder
+        // we keep the module folder structure to prevent issues with modules that are statically
+        // linked using relative paths (Fix #1075)
+        createDirRecursively(tmpFolder);
+        copyFolderRecursiveSync(modulePkgFolder, tmpFolder);
 
         // Example: /tmp/pkg/<hash>/sharp/build/Release/sharp.node
         newPath = path.join(tmpFolder, modulePackagePath, moduleBaseName);


### PR DESCRIPTION
We have an issue reported by several users showing error message “Error: The specified module could not be found.” where some .node files cannot be found in Temp folder under Windows. Because of this error, application cannot be started.
After analysis we have seen that the directories inside temp remain but files are cleaned up (we don’t know which clean up mechanism, Windows OS or antivirus software but we anyway have no means to intervene here). pkg currently only checks for existence of the folder pkg/<hash> and if exists, no copying is done. Since one can never be sure about what happens with files and directories in temporary folder when the application is not active, safer way would be to always do the copying.