### PR TITLE
fix: do not overwrite temp .node files

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -2194,10 +2194,14 @@ function payloadFileSync(pointer) {
         // Example: /tmp/pkg/<hash>/sharp/build/Release/sharp.node
         newPath = path.join(tmpFolder, modulePackagePath, moduleBaseName);
       } else {
-        fs.copyFileSync(modulePath, path.join(tmpFolder, moduleBaseName));
+        const tmpModulePath = path.join(tmpFolder, moduleBaseName);
+
+        if (!fs.existsSync(tmpModulePath)) {
+          fs.copyFileSync(modulePath, tmpModulePath);
+        }
 
         // load the copied file in the temporary folder
-        newPath = path.join(tmpFolder, moduleBaseName);
+        newPath = tmpModulePath;
       }
 
       // replace the path with the new module path


### PR DESCRIPTION
This can happen when two processes try to load the same .node file.