### PR TITLE
fix: `bytecode` option is a boolean

### DIFF
--- a/lib/packer.ts
+++ b/lib/packer.ts
@@ -47,7 +47,7 @@ function hasAnyStore(record: FileRecord) {
 interface PackerOptions {
   records: FileRecords;
   entrypoint: string;
-  bytecode: string;
+  bytecode: boolean;
   symLinks: SymLinks;
 }
 
@@ -159,7 +159,7 @@ export default function packer({
     }
   }
   const prelude =
-    `return (function (REQUIRE_COMMON, VIRTUAL_FILESYSTEM, DEFAULT_ENTRYPOINT, SYMLINKS, DICT, DOCOMPRESS) { 
+    `return (function (REQUIRE_COMMON, VIRTUAL_FILESYSTEM, DEFAULT_ENTRYPOINT, SYMLINKS, DICT, DOCOMPRESS) {
         ${bootstrapText}${
       log.debugMode ? diagnosticText : ''
     }\n})(function (exports) {\n${commonText}\n},\n` +


### PR DESCRIPTION
The `bytecode` CLI flag is specified as a boolean option in the
arguments passed to `minimist`.

My formatter also removed a useless trailing space in the same file...