### PR TITLE
feat: add simple type export (TS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "lib-es5/index.js",
   "license": "MIT",
   "repository": "vercel/pkg",
+  "types": "lib-es5/index.d.ts",
   "bin": {
     "pkg": "lib-es5/bin.js"
   },
   "files": [
     "lib-es5/*.js",
+    "lib-es5/index.d.ts",
     "dictionary/*.js",
     "prelude/*.js"
   ],


### PR DESCRIPTION
While using the pkg API in a typescript project, my editor complained it cannot find the declaration file for pkg. This PR add just the needed declaration file for the API so that the warning mentioned goes away.
