### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/walker.ts
+++ b/lib/walker.ts
@@ -847,7 +847,7 @@ class Walker {
     for (const derivative of derivatives) {
       if (natives[derivative.alias]) continue;
       if (derivative.alias.startsWith('node:')) {
-        if (natives[derivative.alias.substr(5)]) continue;
+        if (natives[derivative.alias.slice(5)]) continue;
       }
       
       switch (derivative.aliasType) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.