### PR TITLE
CI: Add Node 18 to version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false # prevent test to stop if one fails
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest] # Skip macos-latest
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Node 18 became "current" Node.js version today. Add it to version matrix in CI.