### PR TITLE
fix(boootstrap): prevent to override existing node addon file

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -230,7 +230,7 @@ function copyFolderRecursiveSync(source, target) {
           // If checksums are equal then there is nothing to do here
           // ==> target already exists and is up-to-date
           if (curSourceHash === curTargetHash) {
-            return;
+            continue;
           }
         }
 

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -198,6 +198,12 @@ function copyFolderRecursiveSync(source, target) {
         copyFolderRecursiveSync(curSource, targetFolder);
       } else {
         const curTarget = path.join(targetFolder, path.basename(curSource));
+        // Check if the target file already exists and skip the copy in such a case to
+        // 1. avoid an exception that the file cannot be written if it is already opened
+        //    by a running instance of the pkg-packaged app
+        // 2. speed up the second, third, etc. app start if (in best case) all files
+        //    are already existing
+        // See https://github.com/vercel/pkg/issues/1589 for more details.
         if (!fs.existsSync(curTarget)) {
           fs.copyFileSync(curSource, curTarget);
         }

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -197,10 +197,10 @@ function copyFolderRecursiveSync(source, target) {
       if (fs.lstatSync(curSource).isDirectory()) {
         copyFolderRecursiveSync(curSource, targetFolder);
       } else {
-        fs.copyFileSync(
-          curSource,
-          path.join(targetFolder, path.basename(curSource))
-        );
+        const curTarget = path.join(targetFolder, path.basename(curSource));
+        if (!fs.existsSync(curTarget)) {
+          fs.copyFileSync(curSource, curTarget);
+        }
       }
     });
   }


### PR DESCRIPTION
This PR fixes [#1589](https://github.com/vercel/pkg/issues/1589). The fix has two effects:

1. `.node` files that must exist on the real filesystem instead of the virtual snapshot filesystem (because of process.dlopen) are only copied if they do not exist. If they already exist then it doesn't matter anymore whether they are currently opened by an running instance of the pkg-packaged app or not, because existing files are untouched now.
2. The start of the pkg app a second, third, etc. time is as fast as with pkg 5.5.2 again since (in best case) no copy action takes place