### PR TITLE
fix broken tests on node 12; latest pnpm requires node >= 14.19

### DIFF
--- a/test/test-10-pnpm/main.js
+++ b/test/test-10-pnpm/main.js
@@ -7,14 +7,7 @@ const path = require('path');
 const assert = require('assert');
 const utils = require('../utils.js');
 
-// ignore this test if nodejs <= 14.19 , as recent version of PNPM do not support nodejs=14.19
-const MAJOR_VERSION = parseInt(process.version.match(/v([0-9]+)/)[1], 10);
-const MINOR_VERSION = parseInt(process.version.match(/v[0-9]+\.([0-9]+)/)[1], 10);
-if (MAJOR_VERSION < 14 || (MAJOR_VERSION === 14 && MINOR_VERSION < 19)) {
-  console.log(
-    'skiping test as it requires nodejs >= 14.19 and got',
-    `${MAJOR_VERSION}.${MINOR_VERSION}`
-  );
+if (utils.shouldSkipPnpm()) {
   return;
 }
 

--- a/test/test-10-pnpm/main.js
+++ b/test/test-10-pnpm/main.js
@@ -7,12 +7,13 @@ const path = require('path');
 const assert = require('assert');
 const utils = require('../utils.js');
 
-// ignore this test if nodejs <= 10 , as recent version of PNPM do not support nodejs=10
+// ignore this test if nodejs <= 14.19 , as recent version of PNPM do not support nodejs=14.19
 const MAJOR_VERSION = parseInt(process.version.match(/v([0-9]+)/)[1], 10);
-if (MAJOR_VERSION < 12) {
+const MINOR_VERSION = parseInt(process.version.match(/v[0-9]+\.([0-9]+)/)[1], 10);
+if (MAJOR_VERSION < 14 || (MAJOR_VERSION === 14 && MINOR_VERSION < 19)) {
   console.log(
-    'skiping test as it requires nodejs >= 12 and got',
-    MAJOR_VERSION
+    'skiping test as it requires nodejs >= 14.19 and got',
+    `${MAJOR_VERSION}.${MINOR_VERSION}`
   );
   return;
 }

--- a/test/test-11-pnpm/main.js
+++ b/test/test-11-pnpm/main.js
@@ -7,14 +7,7 @@ const path = require('path');
 const assert = require('assert');
 const utils = require('../utils.js');
 
-// ignore this test if nodejs <= 14.19 , as recent version of PNPM do not support nodejs=14.19
-const MAJOR_VERSION = parseInt(process.version.match(/v([0-9]+)/)[1], 10);
-const MINOR_VERSION = parseInt(process.version.match(/v[0-9]+\.([0-9]+)/)[1], 10);
-if (MAJOR_VERSION < 14 || (MAJOR_VERSION === 14 && MINOR_VERSION < 19)) {
-  console.log(
-    'skiping test as it requires nodejs >= 14.19 and got',
-    `${MAJOR_VERSION}.${MINOR_VERSION}`
-  );
+if (utils.shouldSkipPnpm()) {
   return;
 }
 

--- a/test/test-11-pnpm/main.js
+++ b/test/test-11-pnpm/main.js
@@ -7,12 +7,13 @@ const path = require('path');
 const assert = require('assert');
 const utils = require('../utils.js');
 
-// ignore this test if nodejs <= 10 , as recent version of PNPM do not support nodejs=10
+// ignore this test if nodejs <= 14.19 , as recent version of PNPM do not support nodejs=14.19
 const MAJOR_VERSION = parseInt(process.version.match(/v([0-9]+)/)[1], 10);
-if (MAJOR_VERSION < 12) {
+const MINOR_VERSION = parseInt(process.version.match(/v[0-9]+\.([0-9]+)/)[1], 10);
+if (MAJOR_VERSION < 14 || (MAJOR_VERSION === 14 && MINOR_VERSION < 19)) {
   console.log(
-    'skiping test as it requires nodejs >= 12 and got',
-    MAJOR_VERSION
+    'skiping test as it requires nodejs >= 14.19 and got',
+    `${MAJOR_VERSION}.${MINOR_VERSION}`
   );
   return;
 }

--- a/test/test-12-compression-node-opcua/main.js
+++ b/test/test-12-compression-node-opcua/main.js
@@ -16,9 +16,7 @@ const utils = require('../utils.js');
 assert(!module.parent);
 assert(__dirname === process.cwd());
 
-// ignore this test if nodejs <= 10 , as recent version of PNPM do not support nodejs=10
-const MAJOR_VERSION = parseInt(process.version.match(/v([0-9]+)/)[1], 10);
-if (MAJOR_VERSION < 12) {
+if (utils.shouldSkipPnpm()) {
   return;
 }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -174,7 +174,8 @@ module.exports.shouldSkipPnpm = function () {
   const MINOR_VERSION = parseInt(process.version.match(/v[0-9]+\.([0-9]+)/)[1], 10);
 
   const isDisallowedMajor = MAJOR_VERSION < REQUIRED_MAJOR_VERSION
-  if (isDisallowedMajor || (isDisallowedMajor && MINOR_VERSION < REQUIRED_MINOR_VERSION)) {
+  const isDisallowedMinor = MAJOR_VERSION === REQUIRED_MAJOR_VERSION && MINOR_VERSION < REQUIRED_MINOR_VERSION;
+  if (isDisallowedMajor || isDisallowedMinor) {
     const need = `${REQUIRED_MAJOR_VERSION}.${REQUIRED_MINOR_VERSION}`;
     const got = `${MAJOR_VERSION}.${MINOR_VERSION}`;
     console.log(`skiping test as it requires nodejs >= ${need} and got ${got}`);

--- a/test/utils.js
+++ b/test/utils.js
@@ -167,14 +167,15 @@ module.exports.filesAfter = function (b, n) {
 };
 
 module.exports.shouldSkipPnpm = function () {
-  // ignore this test if nodejs <= 14.19 , as recent version of PNPM do not support nodejs=14.19
+  const REQUIRED_MAJOR_VERSION = 14;
+  const REQUIRED_MINOR_VERSION = 19;
+  
   const MAJOR_VERSION = parseInt(process.version.match(/v([0-9]+)/)[1], 10);
   const MINOR_VERSION = parseInt(process.version.match(/v[0-9]+\.([0-9]+)/)[1], 10);
-  if (MAJOR_VERSION < 14 || (MAJOR_VERSION === 14 && MINOR_VERSION < 19)) {
-    console.log(
-      'skiping test as it requires nodejs >= 14.19 and got',
-      `${MAJOR_VERSION}.${MINOR_VERSION}`
-    );
+  if (MAJOR_VERSION < REQUIRED_MAJOR_VERSION || (MAJOR_VERSION === REQUIRED_MAJOR_VERSION && MINOR_VERSION < REQUIRED_MINOR_VERSION)) {
+    const need = `${REQUIRED_MAJOR_VERSION}.${REQUIRED_MINOR_VERSION}`;
+    const got = `${MAJOR_VERSION}.${MINOR_VERSION}`;
+    console.log(`skiping test as it requires nodejs >= ${need} and got`, got);
     return true;
   }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -169,13 +169,15 @@ module.exports.filesAfter = function (b, n) {
 module.exports.shouldSkipPnpm = function () {
   const REQUIRED_MAJOR_VERSION = 14;
   const REQUIRED_MINOR_VERSION = 19;
-  
+
   const MAJOR_VERSION = parseInt(process.version.match(/v([0-9]+)/)[1], 10);
   const MINOR_VERSION = parseInt(process.version.match(/v[0-9]+\.([0-9]+)/)[1], 10);
-  if (MAJOR_VERSION < REQUIRED_MAJOR_VERSION || (MAJOR_VERSION === REQUIRED_MAJOR_VERSION && MINOR_VERSION < REQUIRED_MINOR_VERSION)) {
+
+  const isDisallowedMajor = MAJOR_VERSION < REQUIRED_MAJOR_VERSION
+  if (isDisallowedMajor || (isDisallowedMajor && MINOR_VERSION < REQUIRED_MINOR_VERSION)) {
     const need = `${REQUIRED_MAJOR_VERSION}.${REQUIRED_MINOR_VERSION}`;
     const got = `${MAJOR_VERSION}.${MINOR_VERSION}`;
-    console.log(`skiping test as it requires nodejs >= ${need} and got`, got);
+    console.log(`skiping test as it requires nodejs >= ${need} and got ${got}`);
     return true;
   }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -165,3 +165,18 @@ module.exports.filesAfter = function (b, n) {
     module.exports.vacuum.sync(ni);
   }
 };
+
+module.exports.shouldSkipPnpm = function () {
+  // ignore this test if nodejs <= 14.19 , as recent version of PNPM do not support nodejs=14.19
+  const MAJOR_VERSION = parseInt(process.version.match(/v([0-9]+)/)[1], 10);
+  const MINOR_VERSION = parseInt(process.version.match(/v[0-9]+\.([0-9]+)/)[1], 10);
+  if (MAJOR_VERSION < 14 || (MAJOR_VERSION === 14 && MINOR_VERSION < 19)) {
+    console.log(
+      'skiping test as it requires nodejs >= 14.19 and got',
+      `${MAJOR_VERSION}.${MINOR_VERSION}`
+    );
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Tests on node 12 are failing because pnpm requires `node >= 14.19`.