### PR TITLE
fix: pick up the correct file argument when forking a process

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -74,7 +74,12 @@ if (NODE_VERSION_MAJOR < 12 || require('worker_threads').isMainThread) {
   }
 }
 
-if (process.env.PKG_EXECPATH === EXECPATH) {
+if (process.send) {
+  // if process.send is set, it means the process was forked,
+  // and the runtime file is the third argument
+  process.argv[1] = process.argv[2];
+  process.argv.splice(2, 1);
+} else if (process.env.PKG_EXECPATH === EXECPATH) {
   process.argv.splice(1, 1);
 
   if (process.argv[1] && process.argv[1] !== '-') {

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -75,7 +75,7 @@ if (NODE_VERSION_MAJOR < 12 || require('worker_threads').isMainThread) {
 }
 
 if (process.send) {
-  // if process.send is set, it means the process was forked,
+  // if process.send is set, it means the process was forked (child process),
   // and the runtime file is the third argument
   process.argv[1] = process.argv[2];
   process.argv.splice(2, 1);


### PR DESCRIPTION
This enables you to fork a process with run time arguments, for instance
--max_old_space_size=1024.

This is an old fix by @bergheim. Never submitted a PR for it

Fixes https://github.com/vercel/pkg/issues/459
Fixes https://github.com/vercel/pkg/issues/1461