### PR TITLE
Add patch for ffi-napi and ref-napi

### DIFF
--- a/dictionary/ffi-napi.js
+++ b/dictionary/ffi-napi.js
@@ -1,0 +1,34 @@
+'use strict';
+
+module.exports = {
+  pkg: {
+    patches: {
+      // This patch reimplements the file extraction logic found in the
+      // `prelude/bootstrap.js` file's dlopen() function. This is needed
+      // because pkg's dlopen() ends up calling Node's process.dlopen(),
+      // which is not appropriate for loading shared libraries with ffi-napi.
+      'lib/dynamic_library.js': [
+        'this._path = path;',
+        `
+        if (path.startsWith('/snapshot/')) {
+          const Fs = require('fs');
+          const moduleContent = Fs.readFileSync(path);
+          const hash = require('crypto')
+            .createHash('sha256')
+            .update(moduleContent)
+            .digest('hex');
+          const Path = require('path');
+          const tmpFolder = Path.join(require('os').tmpdir(), 'pkg', hash);
+          const newPath = Path.join(tmpFolder, Path.basename(path));
+          if (!Fs.existsSync(tmpFolder)) {
+            Fs.mkdirSync(tmpFolder, { recursive: true });
+            Fs.copyFileSync(path, newPath);
+          }
+          path = newPath;
+        }
+        this._path = path;
+        `,
+      ],
+    },
+  },
+};

--- a/dictionary/ffi-napi.js
+++ b/dictionary/ffi-napi.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   pkg: {
+    assets: ['build/Release/ffi_bindings.node'],
     patches: {
       // This patch reimplements the file extraction logic found in the
       // `prelude/bootstrap.js` file's dlopen() function. This is needed

--- a/dictionary/ref-napi.js
+++ b/dictionary/ref-napi.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  pkg: {
+    assets: ['prebuilds/linux-x64/node.napi.node'],
+  },
+};

--- a/test/test-79-npm/ffi-napi/ffi-napi.js
+++ b/test/test-79-npm/ffi-napi/ffi-napi.js
@@ -1,0 +1,4 @@
+'use strict';
+
+const vosk = require('vosk');
+console.log('ok');

--- a/test/test-79-npm/ffi-napi/package.json
+++ b/test/test-79-npm/ffi-napi/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "vosk": "0.3.39"
+  }
+}


### PR DESCRIPTION
This is needed because the ffi-napi's native addon for Node is extracted by pkg to the host filesystem, thus any shared library file that is to be loaded must also be extracted.

Do not confuse the Node's badly named `process.dlopen` (which is already handled by pkg's bootstrap script, but is also useless for ffi-napi) with the actual `dlopen` function pointer that ffi-napi loads from the system's library API.

Fixes #1744