### PR TITLE
chore: separate lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,21 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: yarn install
+      - run: yarn lint
+
   test:
     strategy:
       fail-fast: false # prevent test to stop if one fails
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [12, 14, 16, 18]
         os: [ubuntu-latest, windows-latest] # Skip macos-latest
 
     runs-on: ${{ matrix.os }}
@@ -26,7 +36,5 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.node-version }}
 
       - run: yarn install
-      - if: matrix['node-version'] == '16.x' && matrix['os'] == 'ubuntu-latest'
-        run: yarn lint
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false # prevent test to stop if one fails
       matrix:
-        node-version: [12, 14, 16, 18]
+        node-version: [12.x, 14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest] # Skip macos-latest
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We may not know if CI actually failed or flaked out at a glance, separating lint into its own job would make it easier to read.