### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,14 +60,6 @@
     "simple-git-hooks": ">=2.8.0",
     "typescript": "4.7.2"
   },
-  "peerDependencies": {
-    "node-notifier": ">=9.0.1"
-  },
-  "peerDependenciesMeta": {
-    "node-notifier": {
-      "optional": true
-    }
-  },
   "scripts": {
     "clean": "rimraf lib-es5",
     "build": "npm run clean && tsc",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@babel/core": "7.18.2",
     "@types/babel__generator": "7.6.4",
-    "@types/escodegen": "0.0.7",
     "@types/fs-extra": "9.0.13",
     "@types/is-core-module": "2.2.0",
     "@types/minimist": "1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -347,11 +347,6 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@types/escodegen@0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@types/escodegen/-/escodegen-0.0.7.tgz#a1c3e3dfd76da89f01d7d196eebe227ebe4b6eec"
-  integrity sha512-46oENdSRNEJXCNrPJoC3vRolZJpfeEm7yvATkd2bCncKFG0PUEyfBCaoacfpcXH4Y5RRuqdVj3J7TI+wwn2SbQ==
-
 "@types/fs-extra@9.0.13":
   version "9.0.13"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"


### PR DESCRIPTION
See if this works, we might be able to remove a lot of dependencies that's only used (`require`-d) in tests