### PR TITLE
chore: use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,14 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
+
       - uses: actions/cache@v3
         with:
           path: ~/.pkg-cache/
           key: ${{ matrix.os }}-${{ matrix.node-version }}
 
-      - run: yarn install
+      - run: yarn install --immutable
       - if: matrix['node-version'] == '16.x' && matrix['os'] == 'ubuntu-latest'
         run: yarn lint
       - run: yarn build


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Details

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yml
- uses: actions/checkout@v3
- uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node-version }}

- run: yarn install
```

### TO-BE

```yml
- uses: actions/checkout@v3
- uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node-version }}
    cache: yarn

- run: yarn install --immutable
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)
