### PR TITLE
chore: remove eol nodejs in tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -38,7 +38,7 @@ body:
   - type: input
     attributes:
       label: What Node versions, OSs and CPU architectures are you building for?
-      description: 'For example: default, node12, node12-linux-x64, node14-win-arm64'
+      description: 'For example: default, node18, node18-linux-x64, node16-win-arm64'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/02_regression.yml
+++ b/.github/ISSUE_TEMPLATE/02_regression.yml
@@ -44,7 +44,7 @@ body:
   - type: input
     attributes:
       label: What Node versions, OSs and CPU architectures are you building for?
-      description: 'For example: default, node12, node12-linux-x64, node14-win-arm64'
+      description: 'For example: default, node18, node18-linux-x64, node16-win-arm64'
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,8 @@ jobs:
     strategy:
       fail-fast: false # prevent test to stop if one fails
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
-
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -26,7 +25,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.node-version }}
 
       - run: yarn install
-      - if: matrix['node-version'] == '16.x' && matrix['os'] == 'ubuntu-latest'
+      - if: matrix['node-version'] == '18.x' && matrix['os'] == 'ubuntu-latest'
         run: yarn lint
       - run: yarn build
       - run: yarn test

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ pkg [options] <input>
   – Takes package.json from cwd and follows 'bin' entry
     $ pkg .
   – Makes executable for particular target machine
-    $ pkg -t node14-win-arm64 index.js
+    $ pkg -t node16-win-arm64 index.js
   – Makes executables for target machines of your choice
-    $ pkg -t node12-linux,node14-linux,node14-win index.js
+    $ pkg -t node16-linux,node18-linux,node16-win index.js
   – Bakes '--expose-gc' and '--max-heap-size=34' into executable
     $ pkg --options "expose-gc,max-heap-size=34" index.js
   – Consider packageA and packageB to be public
@@ -84,7 +84,7 @@ The entrypoint of your project is a mandatory CLI argument. It may be:
 `pkg` can generate executables for several target machines at a
 time. You can specify a comma-separated list of targets via `--targets`
 option. A canonical target consists of 3 elements, separated by
-dashes, for example `node12-macos-x64` or `node14-linux-arm64`:
+dashes, for example `node18-macos-x64` or `node14-linux-arm64`:
 
 - **nodeRange** (node8), node10, node12, node14, node16 or latest
 - **platform** alpine, linux, linuxstatic, win, macos, (freebsd)

--- a/lib/help.ts
+++ b/lib/help.ts
@@ -32,7 +32,7 @@ export default function help() {
   ${chalk.gray('–')} Makes executable for particular target machine
     ${chalk.cyan('$ pkg -t node14-win-arm64 index.js')}
   ${chalk.gray('–')} Makes executables for target machines of your choice
-    ${chalk.cyan('$ pkg -t node12-linux,node14-linux,node14-win index.js')}
+    ${chalk.cyan('$ pkg -t node16-linux,node18-linux,node18-win index.js')}
   ${chalk.gray(
     '–'
   )} Bakes '--expose-gc' and '--max-heap-size=34' into executable

--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
     "fix": "npm run lint:style -- -w && npm run lint:code -- --fix",
     "prepare": "npm run build",
     "prepublishOnly": "npm run lint",
-    "test": "npm run build && npm run test:14 && npm run test:12 && npm run test:10 && npm run test:host",
-    "test:10": "node test/test.js node10 no-npm",
-    "test:12": "node test/test.js node12 no-npm",
+    "test": "npm run build && npm run test:18 && npm run test:16 && npm run test:14 && npm run test:host",
+    "test:18": "node test/test.js node18 no-npm",
+    "test:16": "node test/test.js node16 no-npm",
     "test:14": "node test/test.js node14 no-npm",
     "test:host": "node test/test.js host only-npm"
   },


### PR DESCRIPTION
As per #1886, here is a PR to drop support for 12 which is EOL and 14 which is EOL in a month.

As some users may rely on those versions, this should be included in a major release.