### PR TITLE
fix: fs/Module/childProcess/process native method.

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -773,6 +773,8 @@ function payloadFileSync(pointer) {
       return fd;
     }
   }
+  
+  fs._ancestor = ancestor;
 
   fs.createReadStream = function createReadStream(path_) {
     if (!insideSnapshot(path_)) {
@@ -1844,6 +1846,8 @@ function payloadFileSync(pointer) {
     _resolveFilename: Module._resolveFilename,
     runMain: Module.runMain,
   };
+  
+  Module.prototype._ancestor = ancestor;
 
   Module.prototype.require = function require(path_) {
     try {
@@ -2071,6 +2075,8 @@ function payloadFileSync(pointer) {
       }
     }
   }
+  
+  childProcess._ancestor = ancestor;
 
   childProcess.spawn = function spawn() {
     const args = cloneArgs(arguments);
@@ -2195,6 +2201,8 @@ function payloadFileSync(pointer) {
     if (/^\\\\\?\\/.test(f)) return f.slice(4);
     return f;
   }
+  
+  process._ancestor = ancestor;
 
   process.dlopen = function dlopen() {
     const args = cloneArgs(arguments);


### PR DESCRIPTION
Simply using `PKG_EXECPATH` to distinguish whether it is a child process is unreliable, which may cause many problems or side effects. For example, when using `child_process.exec` to execute itself, the first parameter must be passed into the js file path. That is to say, when other programs that use pkg to package execute themselves, the first parameter must be passed in the js file path.

The maintainer should consider refactoring this part or directly provide the native method of nodejs. In fact, the maintainer has "backed up" the native method of nodejs
```javascript
const ancestor = {
    spawn: childProcess.spawn,
    spawnSync: childProcess.spawnSync,
    execFile: childProcess.execFile,
    execFileSync: childProcess.execFileSync,
    exec: childProcess.exec,
    execSync: childProcess. execSync,
};
```
Now just add `childProcess._ancestor = ancestor;` on it and everything should be fine.