### PR TITLE
fix: Add missing functions from restored fs.Stats

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -1419,6 +1419,8 @@ function payloadFileSync(pointer) {
     delete s.isSocketValue;
     delete s.isSymbolicLinkValue;
 
+    s.isBlockDevice = noop;
+    s.isCharacterDevice = noop;
     s.isFile = function isFile() {
       return isFileValue;
     };
@@ -1431,9 +1433,7 @@ function payloadFileSync(pointer) {
     s.isSymbolicLink = function isSymbolicLink() {
       return isSymbolicLinkValue;
     };
-    s.isFIFO = function isFIFO() {
-      return false;
-    };
+    s.isFIFO = noop;
 
     return s;
   }


### PR DESCRIPTION
In my project, I noticed that a library that used `isCharacterDevice` on a file from the snapshot crashed. This adds the missing functions as noops (and I made isFIFO use noop so it was clearer).

I thought about making these mirror their files that were included, but I don't think either makes sense within the virtual fs. Please correct me if I'm wrong.