### PR TITLE
fix: missing entrypoint when launched from self-created child process

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -80,14 +80,12 @@ if (process.env.PKG_EXECPATH === EXECPATH) {
   if (process.argv[1] && process.argv[1] !== '-') {
     // https://github.com/nodejs/node/blob/1a96d83a223ff9f05f7d942fb84440d323f7b596/lib/internal/bootstrap/node.js#L269
     process.argv[1] = path.resolve(process.argv[1]);
-  } else {
-    process.argv[1] = DEFAULT_ENTRYPOINT;
   }
 } else {
   process.argv[1] = DEFAULT_ENTRYPOINT;
 }
 
-[, ENTRYPOINT] = process.argv;
+[, ENTRYPOINT = DEFAULT_ENTRYPOINT] = process.argv;
 delete process.env.PKG_EXECPATH;
 
 // /////////////////////////////////////////////////////////////////

--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -80,6 +80,8 @@ if (process.env.PKG_EXECPATH === EXECPATH) {
   if (process.argv[1] && process.argv[1] !== '-') {
     // https://github.com/nodejs/node/blob/1a96d83a223ff9f05f7d942fb84440d323f7b596/lib/internal/bootstrap/node.js#L269
     process.argv[1] = path.resolve(process.argv[1]);
+  } else {
+    process.argv[1] = DEFAULT_ENTRYPOINT;
   }
 } else {
   process.argv[1] = DEFAULT_ENTRYPOINT;

--- a/test/test-99-#1861/index.js
+++ b/test/test-99-#1861/index.js
@@ -1,0 +1,14 @@
+const { spawn } = require('child_process');
+
+const { argv } = process;
+
+if (argv.length <= 2) {
+  console.log('stop');
+  process.exit();
+}
+
+console.log('launch');
+
+const cp = spawn('cmd.exe', ['/C', 'launch.bat'], { shell: true });
+cp.stdout.on('data', (output) => console.log(output.toString()));
+cp.on('close', process.exit);

--- a/test/test-99-#1861/index.js
+++ b/test/test-99-#1861/index.js
@@ -1,3 +1,7 @@
+#!/usr/bin/env node
+
+'use strict';
+
 const { spawn } = require('child_process');
 
 const { argv } = process;

--- a/test/test-99-#1861/launch.bat
+++ b/test/test-99-#1861/launch.bat
@@ -1,0 +1,3 @@
+@echo off
+index.exe
+exit

--- a/test/test-99-#1861/main.js
+++ b/test/test-99-#1861/main.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const utils = require('../utils.js');
+const path = require('path');
+
+assert(!module.parent);
+assert(__dirname === process.cwd());
+
+if (process.platform !== 'win32') {
+  console.log('Skipping this test on non-windows platform.');
+  return 0;
+}
+
+const input = path.join(__dirname, '/index.js');
+const output = path.join(__dirname, '/index.exe');
+
+// build executable
+utils.pkg.sync(['--debug', '--target', 'host', '--output', output, input]);
+
+const log = utils.spawn.sync(output, ['launch'], { expect: 0 });
+
+assert(log.includes('launch'));
+assert(log.includes('stop'));
+
+utils.vacuum.sync(output);


### PR DESCRIPTION
There is a bug that occurs when a packaged executable (Windows 11) is launched from a child process which was created by the executable itself (like for a self updating executable). This bug was reported already in #1861.

It seems that there is a conditional block at the start of `bootstrap.js` which has the potential to cause `ENTRYPOINT` to become `undefined`. I have to admit that I don't understand the purpose of the that specific code block, but I understand as much as that there always needs to be an entrypoint to successfully launch the executable. So I simply added an `else` statement as a fall back to the `DEFAULT_ENTRYPOINT`.