### PR TITLE
add the pkg build prisma example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/prisma-example"]
+	path = examples/prisma-example
+	url = git@github.com:ParseDark/hello-prisma.git


### PR DESCRIPTION
add the new example for the Prisma project.

i found in the mac platform if use the office solution it's not work.
```json
{
  "pkg": {
    "assets": ["node_modules/.prisma/client/*.node"]
  }
}
```

So I create a new example for prisma project. 